### PR TITLE
update D compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Intel(R) Core(TM) i5-2400 CPU @ 3.10GHz (Ubuntu 14.04.1 LTS x86_64)
 * Nim Compiler Version 0.10.2 (2014-12-29) [Linux: amd64]
 * `Crystal 0.5.5 [d814c6c] (Fri Dec 12 22:50:10 UTC 2014)`
 * go version go1.4 linux/amd64
-* DMD64 D Compiler v2.066.1
+* DMD64 D Compiler v2.067.0
+* LDC D Compiler v0.15.1
 * V8 version 3.29.62 (candidate)
 * rustc 0.13.0-nightly (5745e4195 2014-11-12 22:57:16 +0000)
 * Scala compiler version 2.11.4 -- Copyright 2002-2013, LAMP/EPFL


### PR DESCRIPTION
- use 2.067.0 with much better GC performance
- add LDC v0.15.1 with old GC, but faster codegen