### PR TITLE
Use BTreeMap instead of HashMap in brainfuck.rs

### DIFF
--- a/brainfuck/brainfuck.rs
+++ b/brainfuck/brainfuck.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::vec::Vec;
 use std::io;
 use std::env;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 struct Tape {
   pos: usize,
@@ -23,13 +23,13 @@ impl Tape {
 
 struct Program {
   code: Vec<char>,
-  bracket_map: HashMap<usize, usize>
+  bracket_map: BTreeMap<usize, usize>
 }
 
 impl Program {
   fn new(content: String) -> Program {
     let mut code: Vec<char> = Vec::new();
-    let mut bracket_map = HashMap::new();
+    let mut bracket_map = BTreeMap::new();
     let mut leftstack = Vec::new();
     let mut pc = 0;
 


### PR DESCRIPTION
HashMap uses a cryptographically sound hashing algorithm, and so is much slower than BTreeMap. On my system:

```
$ bash run.sh
Rust
ZYXWVUTSRQPONMLKJIHGFEDCBA
8.53s, 2.1Mb

$ bash run.sh
Rust
ZYXWVUTSRQPONMLKJIHGFEDCBA
4.30s, 2.2Mb
```