### PR TITLE
Read file as one piece in C++ implementation of brainfuck benchmark

### DIFF
--- a/brainfuck/brainfuck.cpp
+++ b/brainfuck/brainfuck.cpp
@@ -86,11 +86,12 @@ public:
 
 string read_file(string filename){
   string text;
-  string line;
   ifstream textstream(filename.c_str());
-  while (getline(textstream, line)) {
-    text += line + "\n";
-  }
+  textstream.seekg(0, ios_base::end);
+  const int lenght = textstream.tellg();
+  textstream.seekg(0);
+  string buf(lenght, ' ');
+  textstream.read(&buf[0], lenght);
   textstream.close();
   return text;
 }

--- a/brainfuck/brainfuck.cpp
+++ b/brainfuck/brainfuck.cpp
@@ -85,13 +85,12 @@ public:
 };
 
 string read_file(string filename){
-  string text;
   ifstream textstream(filename.c_str());
   textstream.seekg(0, ios_base::end);
   const int lenght = textstream.tellg();
   textstream.seekg(0);
-  string buf(lenght, ' ');
-  textstream.read(&buf[0], lenght);
+  string text(lenght, ' ');
+  textstream.read(&text[0], lenght);
   textstream.close();
   return text;
 }


### PR DESCRIPTION
Implementations in other languages do same thing. I.e read source file as one piece not line-by-line. There are a lot of frequent memory allocations in each iteration so it might significantly influence on the results