### PR TITLE
Improve Rust matmul benchmark

### DIFF
--- a/matmul/matmul.rs
+++ b/matmul/matmul.rs
@@ -1,9 +1,9 @@
 use std::env;
 
 fn newmat(x: usize, y: usize) -> Vec<Vec<f64>> {
-  let mut r = Vec::new();
+  let mut r = Vec::with_capacity(x);
   for _ in 0..x {
-    let mut c = Vec::new();
+    let mut c = Vec::with_capacity(y);
     for _ in 0..y { c.push(0_f64); }
     r.push(c);
   }


### PR DESCRIPTION
On my i7, this goes from

4.13s, 102.2Mb

to

3.87s, 78.2Mb


The `with_capacity()` preallocates since we already know the final length.

A more ergonomic and common way to do it would be to do:

```rust
fn newmat(x: usize, y: usize) -> Vec<Vec<f64>> {
  let inner = vec![0; y];
  vec![inner; x];
}
```

This has the same perf, but looks cleaner. It's also what most Rust folks would do if asked to "make a 2D vector of x and y dimensions".

I can switch my PR to do this instead if you'd like.