### PR TITLE
[C#] Use String.IndexOf() instead of Any() to find a char in a string

### DIFF
--- a/brainfuck/brainfuck.cs
+++ b/brainfuck/brainfuck.cs
@@ -38,7 +38,7 @@ namespace Test
             for (int i = 0; i < text.Length; i++)
             {
                 char c = text[i];
-                if (!"[]<>+-,.".Any(a => a == c)) continue;
+                if ("[]<>+-,.".IndexOf(c) == -1) continue;
 
                 if (c == '[') leftstack.Push(pc);
                 else


### PR DESCRIPTION
This is a more common way of doing this, and is slightly faster.