### PR TITLE
Changed bracket_map to RedBlackTree, which is faster ATM

### DIFF
--- a/brainfuck/brainfuck.d
+++ b/brainfuck/brainfuck.d
@@ -22,8 +22,11 @@ final:
 };
 
 class Program {
+  import std.container.rbtree;
+  import std.typecons;
+
   string code;
-  int[int] bracket_map;
+  auto bracket_map = new RedBlackTree!(Tuple!(int, int), "a[0]<b[0]")();
 
   this(string text) {
     int[] leftstack;
@@ -39,8 +42,8 @@ class Program {
           int left = leftstack[leftstack.length - 1];
           leftstack.popBack();
           int right = pc;
-          bracket_map[left] = right;
-          bracket_map[right] = left;
+          bracket_map.insert(tuple(left, right));
+          bracket_map.insert(tuple(right, left));
         }
 
       pc++;
@@ -65,10 +68,10 @@ class Program {
           tape.devance();
           break;
         case '[':
-          if (tape.get() == 0) pc = bracket_map[pc];
+          if (tape.get() == 0) pc = bracket_map.equalRange(tuple(pc, 0)).front[1];
           break;
         case ']':
-          if (tape.get() != 0) pc = bracket_map[pc];
+          if (tape.get() != 0) pc = bracket_map.equalRange(tuple(pc, 0)).front[1];
           break;
         case '.':
           write(tape.get().to!char);


### PR DESCRIPTION
D's associative array is not fast enough yet. Can be replaced with RBTree structure, which is much faster.

Tuple is used as a key value pair here.
EqualRange method of rbTree returns all tuples with the same key, front is used to pick first (and only one).

This change gets it (LDC2) from 6s to 3.8s on my PC.