### PR TITLE
add link to mandel.b implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Some benchmarks of different languages
 
 ### mandel.b
 
+[Mandel in Brainfuck](https://github.com/kostya/benchmarks/blob/master/brainfuck/mandel.b)
+
 | Language        | Time,s  | Memory, Mb |
 | --------------- | ------- | ---------- |
 | Nim Clang       | 27.98   | 1.0        |


### PR DESCRIPTION
These benchmarks are great.

Added a link to the information around `mandel.b`. All other implementation have a similar link.

Thanks