### PR TITLE
Optimization for base64/test.scala (24.71s -> 7.42s on i5-4670)

### DIFF
--- a/base64/test.scala
+++ b/base64/test.scala
@@ -1,9 +1,9 @@
 object Base64 {
-  val enc = new sun.misc.BASE64Encoder()
-  val dec = new sun.misc.BASE64Decoder()
+  val enc = java.util.Base64.getEncoder
+  val dec = java.util.Base64.getDecoder
 
-  def encode(str: String) = enc.encode(str.getBytes())
-  def decode(str: String) = dec.decodeBuffer(str)
+  def encode(str: String) = enc.encodeToString(str.getBytes())
+  def decode(str: String) = dec.decode(str)
 
   def main(args: Array[String]): Unit = {
     val STR_SIZE = 10000000


### PR DESCRIPTION
Requires Java 8