### PR TITLE
Update to serde 0.5.1 and use the new serde_json module

### DIFF
--- a/json/json.rs/Cargo.lock
+++ b/json/json.rs/Cargo.lock
@@ -2,86 +2,117 @@
 name = "json-rs"
 version = "0.0.1"
 dependencies = [
- "serde 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aster"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quasi"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quasi_codegen"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quasi_macros"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quasi_codegen 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_codegen"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_macros 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_macros"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/json/json.rs/Cargo.toml
+++ b/json/json.rs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 
 [dependencies]
 serde = "*"
+serde_json = "*"
 serde_macros = "*"
 
 [profile.release]

--- a/json/json.rs/src/main.rs
+++ b/json/json.rs/src/main.rs
@@ -2,9 +2,9 @@
 #![plugin(serde_macros)]
 
 extern crate serde;
+extern crate serde_json;
 
 use serde::{Deserialize, Deserializer, de};
-use serde::json;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -35,7 +35,7 @@ fn main() {
   let mut file = File::open(&path).unwrap();
   file.read_to_end(&mut s).unwrap();
 
-  let jobj: TestStruct = json::de::from_slice(&s).unwrap();
+  let jobj: TestStruct = serde_json::de::from_slice(&s).unwrap();
 
   let len = jobj.coordinates.len() as f64;
   let mut x = 0_f64;


### PR DESCRIPTION
Running the benchmarks on my laptop appear to get rust at the top of the chart:

```
Rust
0.5002999007347979
0.49984222196651984
0.4998791898738121
1.35s, 227.7Mb
...
C++ Rapid
0.5003
0.499842
0.499879
1.90s, 943.5Mb
C++ Gason
0.5003
0.499842
0.499879
1.81s, 924.3Mb
...
```
