### PR TITLE
add perl benchmarks for base64 and json, pure-perl and XS

### DIFF
--- a/base64/build.sh
+++ b/base64/build.sh
@@ -20,3 +20,4 @@ if [ ! -d aklomp-base64-ssse ]; then
   cd -
 fi
 gcc --std=c99 -O3 test-aklomp.c -I aklomp-base64-ssse/include/ aklomp-base64-ssse/lib/libbase64.o -o base64_c_ak_ssse
+wget -qO - https://cpanmin.us | perl - -L perllib MIME::Base64::Perl

--- a/base64/clean.sh
+++ b/base64/clean.sh
@@ -7,3 +7,4 @@ rm -rf nimcache
 rm -rf base64.rs/target
 rm -rf aklomp-base64*
 rm base64.rs/Cargo.lock
+rm -rf perllib

--- a/base64/run.sh
+++ b/base64/run.sh
@@ -36,3 +36,7 @@ echo Ruby
 ../xtime.rb ruby test.rb
 echo Mono
 ../xtime.rb mono -O=all --gc=sgen test.exe
+echo Perl
+../xtime.rb perl -Iperllib/lib/perl5 test.pl
+echo Perl XS
+../xtime.rb perl test-xs.pl

--- a/base64/test-xs.pl
+++ b/base64/test-xs.pl
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use MIME::Base64 qw(encode_base64 decode_base64);
+use Time::HiRes 'time';
+
+use constant STR_SIZE => 10_000_000;
+use constant TRIES => 100;
+
+my $str = 'a' x STR_SIZE;
+my $str2 = '';
+
+my ($t, $s) = (time, 0);
+for (0..TRIES) {
+  $str2 = encode_base64 $str, '';
+  $s += length $str2;
+}
+print "encode: $s, ", (time - $t), "\n";
+
+($t, $s) = (time, 0);
+for (0..TRIES) {
+  $s += length decode_base64 $str2;
+}
+print "decode: $s, ", (time - $t), "\n";

--- a/base64/test.pl
+++ b/base64/test.pl
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use MIME::Base64::Perl qw(encode_base64 decode_base64);
+use Time::HiRes 'time';
+
+use constant STR_SIZE => 10_000_000;
+use constant TRIES => 100;
+
+my $str = 'a' x STR_SIZE;
+my $str2 = '';
+
+my ($t, $s) = (time, 0);
+for (0..TRIES) {
+  $str2 = encode_base64 $str, '';
+  $s += length $str2;
+}
+print "encode: $s, ", (time - $t), "\n";
+
+($t, $s) = (time, 0);
+for (0..TRIES) {
+  $s += length decode_base64 $str2;
+}
+print "decode: $s, ", (time - $t), "\n";

--- a/json/build.sh
+++ b/json/build.sh
@@ -39,3 +39,5 @@ cp Newtonsoft.Json.*/lib/net45/Newtonsoft.Json.dll .
 mcs -debug- -optimize+ -r:Newtonsoft.Json.dll test.cs
 
 gem install yajl-ruby
+
+wget -qO - https://cpanmin.us | perl - -L perllib Cpanel::JSON::XS JSON::Tiny File::Slurper

--- a/json/clean.sh
+++ b/json/clean.sh
@@ -11,3 +11,4 @@ rm -rf gason
 rm -rf json.rs/target
 rm -rf fast
 rm json.rs/Cargo.lock
+rm -rf perllib

--- a/json/run.sh
+++ b/json/run.sh
@@ -48,3 +48,7 @@ echo Scala
 ../xtime.rb scala -J-Xmx3024m TestJson
 echo q
 ../xtime.rb q test.q -q
+echo Perl
+../xtime.rb perl -Iperllib/lib/perl5 test.pl
+echo Perl XS
+../xtime.rb perl -Iperllib/lib/perl5 test-xs.pl

--- a/json/test-xs.pl
+++ b/json/test-xs.pl
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use File::Slurper 'read_binary';
+use Cpanel::JSON::XS 'decode_json';
+
+my $jobj = decode_json read_binary '1.json';
+my $coordinates = $jobj->{coordinates};
+my $len = @$coordinates;
+my $x = my $y = my $z = 0;
+
+foreach my $coord (@$coordinates) {
+  $x += $coord->{x};
+  $y += $coord->{y};
+  $z += $coord->{z};
+}
+
+print $x / $len, "\n";
+print $y / $len, "\n";
+print $z / $len, "\n";

--- a/json/test.pl
+++ b/json/test.pl
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use File::Slurper 'read_binary';
+use JSON::Tiny 'decode_json';
+
+my $jobj = decode_json read_binary '1.json';
+my $coordinates = $jobj->{coordinates};
+my $len = @$coordinates;
+my $x = my $y = my $z = 0;
+
+foreach my $coord (@$coordinates) {
+  $x += $coord->{x};
+  $y += $coord->{y};
+  $z += $coord->{z};
+}
+
+print $x / $len, "\n";
+print $y / $len, "\n";
+print $z / $len, "\n";


### PR DESCRIPTION
XS implementations are in C but they are normally what is used. Pure-perl benchmarks included for completeness. Requires at least perl 5.8.1. `wget -qO -` in build scripts can be replaced with `curl -L` if desired.