### PR TITLE
Improve RapidJSON performance

### DIFF
--- a/json/build.sh
+++ b/json/build.sh
@@ -25,6 +25,7 @@ if [ ! -d rapidjson ]; then
   git clone --depth 1 https://github.com/miloyip/rapidjson.git
 fi
 g++ -O3 test_rapid.cpp -o json_rapid_cpp -Irapidjson/include
+g++ -O3 test_rapid_sax.cpp -o json_rapid_sax_cpp -Irapidjson/include
 
 if [ ! -d gason ]; then
   git clone --depth 1 https://github.com/vivkin/gason.git

--- a/json/run.sh
+++ b/json/run.sh
@@ -32,6 +32,8 @@ echo C++ Boost
 ../xtime.rb ./json_boost_cpp
 echo C++ Rapid
 ../xtime.rb ./json_rapid_cpp
+echo C++ Rapid SAX
+../xtime.rb ./json_rapid_sax_cpp
 echo C++ Gason
 ../xtime.rb ./json_gason_cpp
 echo C++ LibJson

--- a/json/test_rapid.cpp
+++ b/json/test_rapid.cpp
@@ -14,7 +14,7 @@ int main() {
     jobj.ParseStream(frs);
 
     const Value &coordinates = jobj["coordinates"];
-    int len = coordinates.Size();
+    SizeType len = coordinates.Size();
     double x = 0, y = 0, z = 0;
 
     for (SizeType i = 0; i < len; i++) {

--- a/json/test_rapid.cpp
+++ b/json/test_rapid.cpp
@@ -1,30 +1,17 @@
 #include "rapidjson/document.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/stringbuffer.h"
+#include "rapidjson/filereadstream.h"
+#include <cstdio>
 #include <iostream>
-#include <fstream>
-#include <sstream>
-#include <string>
 
 using namespace std;
-
-void read_file(string filename, stringstream &buffer){
-  ifstream f(filename.c_str());
-  if (f)
-  {
-    buffer << f.rdbuf();
-    f.close();
-  }
-}
-
 using namespace rapidjson;
 
 int main() {
-    std::stringstream ss;
-    read_file("./1.json", ss);
-
-    string text = ss.str();
-    Document jobj; jobj.Parse(text.c_str());
+    FILE* fp = std::fopen("./1.json", "r");
+    char buffer[65536];
+    FileReadStream frs(fp, buffer, sizeof(buffer));
+    Document jobj; 
+    jobj.ParseStream(frs);
 
     const Value &coordinates = jobj["coordinates"];
     int len = coordinates.Size();
@@ -40,6 +27,8 @@ int main() {
     std::cout << x / len << std::endl;
     std::cout << y / len << std::endl;
     std::cout << z / len << std::endl;
+
+    fclose(fp);
 
     return 0;
 }

--- a/json/test_rapid_sax.cpp
+++ b/json/test_rapid_sax.cpp
@@ -1,0 +1,103 @@
+#include "rapidjson/reader.h"
+#include "rapidjson/filereadstream.h"
+#include <cstdio>
+#include <iostream>
+
+using namespace std;
+using namespace rapidjson;
+
+class CoordinateHandler : public BaseReaderHandler<UTF8<>, CoordinateHandler> {
+public:
+  CoordinateHandler() : state_(kStart), x_(), y_(), z_() {}
+
+  bool Double(double d) { 
+    switch (state_) {
+      case kX: x_ += d; state_ = kCoordinatesElement; break;
+      case kY: y_ += d; state_ = kCoordinatesElement; break;
+      case kZ: z_ += d; state_ = kCoordinatesElement; break;
+      default: break;
+    }
+    return true;
+  }
+
+  bool StartObject() {
+    switch (state_) {
+      case kStart: state_ = kRoot; break;
+      case kCoordinatesArray: state_ = kCoordinatesElement; break;
+      default: break;
+    }
+    return true;
+  }
+
+  bool Key(const Ch* str, SizeType len, bool copy) { 
+    switch (state_) {
+      case kRoot:
+        if (len == sizeof("coordinates") - 1 && memcmp(str, "coordinates", sizeof("coordinates") - 1) == 0)
+          state_ = kCoordinates;
+        break;
+
+      case kCoordinatesElement:
+        if (len == 1 && str[0] >= 'x' && str[0] <= 'z')
+          state_ = static_cast<State>(kX + (str[0] - 'x'));
+        break;
+
+      default: break;
+    }
+    return true;
+  }
+
+  bool EndObject(SizeType) {
+    switch (state_) {
+      case kCoordinatesElement: state_ = kCoordinatesArray; break;
+      default: break;
+    }
+    return true;
+  }
+
+  bool StartArray() {
+    switch (state_) {
+      case kCoordinates: state_ = kCoordinatesArray; break;
+      default: break;
+    }
+    return true;
+  }
+
+  bool EndArray(SizeType len) {
+    switch (state_) {
+      case kCoordinatesArray:
+        std::cout << x_ / len << std::endl;
+        std::cout << y_ / len << std::endl;
+        std::cout << z_ / len << std::endl;
+        state_ = kCoordinates;
+        break;
+
+      default: break;
+    }
+    return true;
+  }
+
+private:
+  enum State {
+    kStart,
+    kRoot,
+    kCoordinates,
+    kCoordinatesArray,
+    kCoordinatesElement,
+    kX,
+    kY,
+    kZ
+  }state_;
+  double x_, y_, z_;
+};
+
+int main() {
+    FILE* fp = std::fopen("./1.json", "r");
+    char buffer[65536];
+    FileReadStream frs(fp, buffer, sizeof(buffer));
+
+    Reader reader;
+    CoordinateHandler handler;
+    reader.Parse(frs, handler);
+
+    fclose(fp);
+}


### PR DESCRIPTION
By using `FileReadStream` instead of C++ iostream converisons, less time was spent in reading the file. Also, provided a SAX version which is faster and cost much less memory.

On my rMBP:
~~~
Original
1.64s, 1031.5Mb

Using FileReadStream
0.75s, 336.3Mb

SAX
0.43s, 0.7Mb
~~~