### PR TITLE
Python3 + ujson for Python JSON benchmarks

### DIFF
--- a/json/build.sh
+++ b/json/build.sh
@@ -51,3 +51,6 @@ cd json-hs; make; cd ..
 
 # clojure
 cd json-clj; lein uberjar; cd ..; cp json-clj/test.jar ./
+
+# python/python3/pypy
+pip install ujson

--- a/json/run.sh
+++ b/json/run.sh
@@ -32,6 +32,10 @@ echo Python Pypy
 ../xtime.rb pypy test.py
 echo Python
 ../xtime.rb python test.py
+echo Python3
+../xtime.rb python3 test.py
+echo Python ujson
+../xtime.rb python test_ujson.py
 echo C++ Boost
 ../xtime.rb ./json_boost_cpp
 echo C++ Rapid
@@ -62,4 +66,3 @@ echo Haskell
 ../xtime.rb ./json_hs
 echo Clojure
 ../xtime.rb java -server -jar test.jar
-

--- a/json/test_ujson.py
+++ b/json/test_ujson.py
@@ -1,0 +1,22 @@
+import ujson as json
+
+def test_json():
+    with open('./1.json', 'r') as f:
+        jobj = json.loads(f.read())
+    l = len(jobj['coordinates'])
+    x = 0
+    y = 0
+    z = 0
+
+    for coord in jobj['coordinates']:
+      x += coord['x']
+      y += coord['y']
+      z += coord['z']
+
+    print(x / l)
+    print(y / l)
+    print(z / l)
+
+if __name__ == '__main__':
+    test_json()
+


### PR DESCRIPTION
Added a commonly used Python library when you want to quickly parse JSON. It is much faster than the built in JSON library and is commonly used.

Also, Python3 support since the original script supports it.