### PR TITLE
A jq version of the JSON benchmark

### DIFF
--- a/json/run.sh
+++ b/json/run.sh
@@ -68,3 +68,5 @@ echo Haskell
 ../xtime.rb ./json_hs
 echo Clojure
 ../xtime.rb java -server -jar test.jar
+echo jq
+../xtime.rb jq -r '.coordinates | length as $len | (map(.x) | add) / $len, (map(.y) | add) / $len, (map(.z) | add) / $len' 1.json


### PR DESCRIPTION
This adds an implementation of the JSON benchmark in [jq](http://stedolan.github.io/jq/), a specialized tool/DSL for processing JSON.

You can install jq with

    sudo apt-get install jq
