### PR TITLE
Havlak Nim fix for 0.12.0 compiler version

### DIFF
--- a/havlak/havlak.nim
+++ b/havlak/havlak.nim
@@ -33,7 +33,7 @@ proc NewCfg(): Cfg =
 
 proc createNode(self: var Cfg, name: int): ref BasicBlock =
   var node: ref BasicBlock
-  node = self.basicBlockMap[name]
+  node = self.basicBlockMap.getOrDefault(name)
   if node == nil:
     node = NewBasicBlock(name)
     self.basicBlockMap.add name, node


### PR DESCRIPTION
It fixes crash on Nim 0.12.0.
tables.[] behavior is the first in the list of breaking changes in http://nim-lang.org/news.html#Z2015-10-27-version-0-12-0-released
I changed only one of four occurences as other cases seem to behave correctly (exception if not found).