### PR TITLE
Julia use Float64 by default, so conversion is unnecessary

### DIFF
--- a/matmul/matmul-native.jl
+++ b/matmul/matmul-native.jl
@@ -1,6 +1,6 @@
 function matgen(n)
   tmp = 1.0 / n / n
-  [ float64(tmp * (i - j) * (i + j - 2)) for i=1:n, j=1:n ]
+  [ tmp * (i - j) * (i + j - 2) for i=1:n, j=1:n ]
 end
 
 function main()

--- a/matmul/matmul.jl
+++ b/matmul/matmul.jl
@@ -1,10 +1,10 @@
 function matgen(n)
   tmp = 1.0 / n / n
-  [ float64(tmp * (i - j) * (i + j - 2)) for i=1:n, j=1:n ]
+  [ tmp * (i - j) * (i + j - 2) for i=1:n, j=1:n ]
 end
 
 function mul_line(n, linea, lineb)
-  s = float64(0)
+  s = 0.0
   for i=1:n
     s += linea[i] * lineb[i]
   end


### PR DESCRIPTION
unnecessary conversion to Float64 during matrix creation significantly slow down the algorithm