### PR TITLE
Improve the performance of the BF interpreter in Tcl

### DIFF
--- a/brainfuck/brainfuck.tcl
+++ b/brainfuck/brainfuck.tcl
@@ -1,99 +1,111 @@
 package require Tcl 8.6
 
-namespace eval ::brainfuck {}
+namespace eval ::brainfuck {
+    variable verson 0.2.0
+    variable debug 0
 
-::oo::class create ::brainfuck::Interpreter {
-    constructor {} {
-        my variable tape
-        my variable pos
-
-        set tape [lrepeat 30000 0]
-        set pos 0
-    }
-
-    # Return a dictionary that matches each opening bracket to a closing bracket
-    # and vice versa.
-    method indexBrackets program {
-        set length [llength $program]
-
-        set index {}
-        set level 0
-        set brackets {}
-        set i 0
-        foreach c $program {
-            switch -exact -- $c {
-                [ {
-                    incr level
-                    dict set brackets $level $i 
-                }
-                ] {
-                    set match [dict get $brackets $level]
-                    dict set index $i $match
-                    dict set index $match $i
-                    incr level -1
-                }
-                default {}
-            }
-            incr i
+    proc emit code {
+        upvar 1 transl transl
+        foreach line [split [string trim $code] \n] {
+            append transl [string trimleft $line]\n
         }
-        return $index
     }
 
-    method interpret source {
-        my variable tape
-        my variable pos
+    proc translate source {
+        set transl {}
+        emit {
+            if {![info exists tape] || ($tape eq {})} {
+                for {set i 0} {$i < 30000} {incr i} {
+                    dict set tape $i 0
+                }
+            }
+            if {![info exists pos] || ($pos eq {})} {
+                set pos 0
+            }
+        }
 
-        set counter 0 ;# Program counter.
-
-        set program [split $source {}]
-        set length [llength $program]
-
-        set bracketIndex [my indexBrackets $program]
-
-        while {$counter < $length} {
-            set op [lindex $program $counter]
-            switch -exact -- $op {
+        set commands [split $source {}]
+        for {set i 0} {$i < [llength $commands]} {incr i} {
+            switch -exact -- [lindex $commands $i] {
                 [ {
-                    if {[lindex $tape $pos] == 0} {
-                        set counter [dict get $bracketIndex $counter]
-                    }
+                    emit [string cat {if {[dict get $tape $pos] != 0} } \{]
+                    emit "while 1 \{"
                 }
                 ] {
-                    if {[lindex $tape $pos] != 0} {
-                        set counter [dict get $bracketIndex $counter]
-                    }
+                    emit {if {[dict get $tape $pos] == 0} {break}}
+                    emit \}
+                    emit \}
                 }
-                > {
-                    incr pos
-                }
+                > -
                 < {
-                    incr pos -1
+                    # Compress repeated Brainfuck instructions into a single Tcl
+                    # command.
+                    if {[lindex $commands $i] eq {<}} {
+                        set op <
+                        set sign -
+                    } else {
+                        set op >
+                        set sign +
+                    }
+
+                    set count 0
+                    while {[lindex $commands $i] eq $op} {
+                        incr count
+                        incr i
+                    }
+                    incr i -1
+
+                    emit [format {incr pos %s%d} $sign $count]                
                 }
-                + {
-                    set value [lindex $tape $pos]
-                    incr value
-                    lset tape $pos $value
-                }
+                + -
                 - {
-                    set value [lindex $tape $pos]
-                    incr value -1
-                    lset tape $pos $value
+                    if {[lindex $commands $i] eq {+}} {
+                        set op +
+                    } else {
+                        set op -
+                    }
+
+                    set count 0
+                    while {[lindex $commands $i] eq $op} {
+                        incr count
+                        incr i
+                    }
+                    incr i -1
+
+                    emit [format {dict incr tape $pos %s%d} $op $count]
                 }
                 . {
-                    set value [lindex $tape $pos]
-                    puts -nonewline [format %c $value]
+                    emit {
+                        puts -nonewline [format %c [dict get $tape $pos]]
+                    }
                 }
                 , {
                     # Noncompliant implementation.
-                    set input [read stdin 1]
-                    lset tape $pos [scan $input %c]
+                    emit {
+                        set input [read stdin 1]
+                        dict set tape $pos [scan $input %c]
+                    }
                 }
                 default {
                     # Ignore.
                 }
             }
-            incr counter
         }
+        emit {
+            return [list $tape $pos]
+        }
+        return $transl
+    }
+
+    proc interpret source {
+        variable debug
+
+        set translated [translate $source]
+        if {$debug} {
+            puts $translated
+        }
+        set result [apply [list {{tape {}} {pos {}}} $translated]]
+        return $result
     }
 }
 
@@ -104,9 +116,7 @@ proc main filename {
 
     fconfigure stdout -buffering none
 
-    set bf [::brainfuck::Interpreter new]
-    $bf interpret $source
-    $bf destroy
+    ::brainfuck::interpret $source
 }
 
 main [lindex $argv 0]

--- a/brainfuck/run2.sh
+++ b/brainfuck/run2.sh
@@ -28,6 +28,8 @@ echo Mono
 ../xtime.rb mono -O=all --gc=sgen brainfuck.exe mandel.b > /dev/null
 echo Felix
 ../xtime.rb ./brainfuck_flx mandel.b > /dev/null
+echo Tcl
+../xtime.rb tclsh brainfuck.tcl mandel.b > /dev/null
 echo Java
 ../xtime.rb java brainfuck mandel.b > /dev/null
 


### PR DESCRIPTION
The reworked interpreter is fast enough to run the `mandel.b` benchmark in reasonable time. This PR adds it to `brainfuck/run2.sh`.
