### PR TITLE
Avoid JIT confounding when timing Julia.

### DIFF
--- a/base64/test.jl
+++ b/base64/test.jl
@@ -25,4 +25,13 @@ function main()
   print(s, ", ", time() - t, "\n")
 end
 
-@time main()
+function test()
+  for i in 1:2    # First time it's also JIT compiling!
+    x = @timed main()
+    if i == 2
+      println("Elapsed: $(x[2]), Allocated: $(x[3]), GC Time: $(x[4])")
+    end
+  end
+end
+
+test()

--- a/brainfuck/brainfuck.jl
+++ b/brainfuck/brainfuck.jl
@@ -85,4 +85,13 @@ function main()
   run(p)
 end
 
-@time main()
+function test()
+  for i in 1:2    # First time it's also JIT compiling!
+    x = @timed main()
+    if i == 2
+      println("Elapsed: $(x[2]), Allocated: $(x[3]), GC Time: $(x[4])")
+    end
+  end
+end
+
+test()

--- a/json/test.jl
+++ b/json/test.jl
@@ -18,4 +18,13 @@ function main()
   println(z / len)
 end
 
-@time main()
+function test()
+  for i in 1:2    # First time it's also JIT compiling!
+    x = @timed main()
+    if i == 2
+      println("Elapsed: $(x[2]), Allocated: $(x[3]), GC Time: $(x[4])")
+    end
+  end
+end
+
+test()

--- a/matmul/matmul-native.jl
+++ b/matmul/matmul-native.jl
@@ -18,4 +18,13 @@ function main()
   println(time() - t)
 end
 
-@time main()
+function test()
+  for i in 1:2    # First time it's also JIT compiling!
+    x = @timed main()
+    if i == 2
+      println("Elapsed: $(x[2]), Allocated: $(x[3]), GC Time: $(x[4])")
+    end
+  end
+end
+
+test()

--- a/matmul/matmul.jl
+++ b/matmul/matmul.jl
@@ -35,4 +35,13 @@ function main()
   println(time() - t)
 end
 
-@time main()
+function test()
+  for i in 1:2    # First time it's also JIT compiling!
+    x = @timed main()
+    if i == 2
+      println("Elapsed: $(x[2]), Allocated: $(x[3]), GC Time: $(x[4])")
+    end
+  end
+end
+
+test()


### PR DESCRIPTION
Enhances https://github.com/kostya/benchmarks/commit/9605336fae0bd76142adc3b302d9b0659c13e539
reference: https://github.com/kostya/benchmarks/issues/78

The first timing should be discarded as it is also timing the just in time compilation of the function being tested  (in this case `test`) and the compilation of the `@time` macro.