### PR TITLE
brainfuck.jl: Don't start with uninitialized array.

### DIFF
--- a/brainfuck/brainfuck.jl
+++ b/brainfuck/brainfuck.jl
@@ -3,7 +3,7 @@ type Tape
   pos::Int
 
   function Tape()
-    new(Array(Int, 1), 1)
+    new(zeros(Int, 1), 1)
   end
 end
 


### PR DESCRIPTION
``zeros(Int, 1)`` creates array initialized to ``[0]``.