### PR TITLE
Make the D Brainfuck example faster

### DIFF
--- a/brainfuck/brainfuck.d
+++ b/brainfuck/brainfuck.d
@@ -23,12 +23,13 @@ final:
 
 class Program {
   string code;
-  int[int] bracket_map;
+  int[] bracket_map;
 
   this(string text) {
     int[] leftstack;
     int pc = 0;
 
+    bracket_map.length = 10;
     for (int i = 0; i < text.length; i++) {
       char c = text[i];
       if (!canFind("[]<>+-,.", c)) continue;
@@ -45,6 +46,8 @@ class Program {
 
       pc++;
       code ~= c;
+      if (pc >= bracket_map.length)
+        bracket_map.length *= 2;
     }
   }
 


### PR DESCRIPTION
As you can see, it's moderately easy to make D 2/3x as fast!
Also you should probably update your ldc compiler - the current version does automatic inlining in release mode (hence there is no `-inline` anymore`).

Here are my result for the top half of the languages:

```
Cpp
ZYXWVUTSRQPONMLKJIHGFEDCBA
4.80s, 1.5Mb
Rust
ZYXWVUTSRQPONMLKJIHGFEDCBA
5.91s, 5.6Mb
D
ZYXWVUTSRQPONMLKJIHGFEDCBA
2.85s, 1.3Mb
D Gdc
ZYXWVUTSRQPONMLKJIHGFEDCBA
3.35s, 2.8Mb
D Ldc
ZYXWVUTSRQPONMLKJIHGFEDCBA
2.31s, 6.6Mb
Nim Gcc
ZYXWVUTSRQPONMLKJIHGFEDCBA
3.54s, 1.0Mb
Nim Clang
ZYXWVUTSRQPONMLKJIHGFEDCBA
3.54s, 1.0Mb
Scala
warmup
time: 5.891221898s
run
ZYXWVUTSRQPONMLKJIHGFEDCBA
time: 5.784182207s
11.97s, 3.0Mb
Julia
warming
bench
ZYXWVUTSRQPONMLKJIHGFEDCBA
Elapsed: 8.03399548, Allocated: 76123, GC Time: 0.0
16.31s, 106.4Mb
Java
ZYXWVUTSRQPONMLKJIHGFEDCBA
time: 5.172s
5.25s, 195.4Mb
```

(I couldn't get Felix to work on my machine)