### PR TITLE
base64: build.sh: build C aklomp with OpenMP support

### DIFF
--- a/base64/build.sh
+++ b/base64/build.sh
@@ -18,8 +18,8 @@ mcs -debug- -optimize+ test.cs
 if [ ! -d aklomp-base64-ssse ]; then
   git clone --depth 1 https://github.com/aklomp/base64.git aklomp-base64-ssse
   cd aklomp-base64-ssse
-  SSSE3_CFLAGS=-mssse3 make
+  SSSE3_CFLAGS=-mssse3 OPENMP=1 make
   cd -
 fi
-gcc --std=c99 -O3 test-aklomp.c -I aklomp-base64-ssse/include/ aklomp-base64-ssse/lib/libbase64.o -o base64_c_ak_ssse
+gcc -fopenmp --std=c99 -O3 test-aklomp.c -I aklomp-base64-ssse/include/ aklomp-base64-ssse/lib/libbase64.o -o base64_c_ak_ssse
 wget -qO - https://cpanmin.us | perl - -L perllib MIME::Base64::Perl


### PR DESCRIPTION
Build the base64-C-aklomp library with OpenMP support. The library has been significantly improved (made faster) since the first benchmark round. One of the improvements is the addition of OpenMP parallellization; this commit adds support for it. Should work out of the box on modern GCC and LLVM.

Disclaimer: I am the library's author.