### PR TITLE
enable LTO in C, C++ and Rust benchmarks

### DIFF
--- a/base64/build.sh
+++ b/base64/build.sh
@@ -1,8 +1,8 @@
 crystal build test.cr --release -o base64_cr
 go build -o base64_go test.go
 gccgo -O3 -g -o base64_go_gccgo test.go
-g++ -O3 -o base64_cpp test.cpp -lcrypto
-gcc -O3 -std=c99 -o base64_c test.c
+g++ -flto -O3 -o base64_cpp test.cpp -lcrypto
+gcc -flto -O3 -std=c99 -o base64_c test.c
 scalac -optimize test.scala
 javac Base64Java.java
 kotlinc Test.kt -include-runtime -d Test-kt.jar

--- a/brainfuck/build.sh
+++ b/brainfuck/build.sh
@@ -1,9 +1,9 @@
 crystal build brainfuck.cr --release -o brainfuck_cr
 go build -o brainfuck_go brainfuck.go
 gccgo -O3 -g -o brainfuck_go_gccgo brainfuck.go
-g++ -O3 -o brainfuck_cpp brainfuck.cpp
+g++ -flto -O3 -o brainfuck_cpp brainfuck.cpp
 scalac -optimize brainfuck.scala
-rustc -C opt-level=3 brainfuck.rs -o brainfuck_rs
+rustc -C lto -C opt-level=3 brainfuck.rs -o brainfuck_rs
 dmd -ofbrainfuck_d -O -release -inline brainfuck.d
 gdc -o brainfuck_d_gdc -O3 -frelease -finline brainfuck.d
 ldc2 -ofbrainfuck_d_ldc -O5 -release -inline brainfuck.d

--- a/brainfuck2/build.sh
+++ b/brainfuck2/build.sh
@@ -1,6 +1,6 @@
 crystal build bf.cr --release -o bin_cr
-g++ -O3 -o bin_cpp bf.cpp
-rustc -C opt-level=3 bf.rs -o bin_rs
+g++ -flto -O3 -o bin_cpp bf.cpp
+rustc -C lto -C opt-level=3 bf.rs -o bin_rs
 scalac -optimize bf.scala
 mcs -debug- -optimize+ bf.cs
 javac bf.java
@@ -12,4 +12,3 @@ gdc -o bin_d_gdc -O3 -frelease -finline bf.d
 ldc2 -ofbin_d_ldc -O5 -release -inline bf.d
 nim c -o:bin_nim_clang -d:release --cc:clang --verbosity:0 bf.nim
 nim c -o:bin_nim_gcc -d:release --cc:gcc --verbosity:0 bf.nim
-

--- a/havlak/build.sh
+++ b/havlak/build.sh
@@ -1,9 +1,9 @@
 crystal build havlak.cr --release -o havlak_cr
 go build -o havlak_go havlak.go
 gccgo -O3 -g -o havlak_go_gccgo havlak.go
-g++ -O3 -o havlak_cpp havlak.cpp
+g++ -flto -O3 -o havlak_cpp havlak.cpp
 scalac -optimize havlak.scala
-rustc --opt-level 3 havlak.rs -o havlak_rs
+rustc -C lto -C opt-level=3 havlak.rs -o havlak_rs
 dmd -ofhavlak_d -O -release -inline havlak.d
 gdc -o havlak_d_gdc -O3 -frelease -finline havlak.d
 ldc2 -ofhavlak_d_ldc -O5 -release -inline havlak.d

--- a/json/build.sh
+++ b/json/build.sh
@@ -16,7 +16,7 @@ nim c -o:json_nim_gcc -d:release --cc:gcc --verbosity:0 test.nim
 nim c -o:json_nim_clang -d:release --cc:clang --verbosity:0 test.nim
 go build -o json_go test.go
 gccgo -O3 -g -o json_go_gccgo test.go
-g++ -O3 test_boost.cpp -o json_boost_cpp
+g++ -flto -O3 test_boost.cpp -o json_boost_cpp
 
 if [ ! -d fast ]; then
   git clone --depth 1 --branch v0.3.0 https://github.com/mleise/fast.git
@@ -26,15 +26,15 @@ gdc -o json_d_gdc_fast -O3 -frelease test_fast.d fast/source/fast/cstring.d fast
 if [ ! -d rapidjson ]; then
   git clone --depth 1 https://github.com/miloyip/rapidjson.git
 fi
-g++ -O3 test_rapid.cpp -o json_rapid_cpp -Irapidjson/include
-g++ -O3 test_rapid_sax.cpp -o json_rapid_sax_cpp -Irapidjson/include
+g++ -flto -O3 test_rapid.cpp -o json_rapid_cpp -Irapidjson/include
+g++ -flto -O3 test_rapid_sax.cpp -o json_rapid_sax_cpp -Irapidjson/include
 
 if [ ! -d gason ]; then
   git clone --depth 1 https://github.com/vivkin/gason.git
 fi
-g++ -std=c++11 test_gason.cpp -I gason/src/ gason/src/gason.cpp -o json_gason_cpp -O3
+g++ -flto -std=c++11 test_gason.cpp -I gason/src/ gason/src/gason.cpp -o json_gason_cpp -O3
 
-g++ -O3 test_libjson.cpp -o json_libjson_cpp -ljson
+g++ -flto -O3 test_libjson.cpp -o json_libjson_cpp -ljson
 julia -e 'Pkg.add("JSON")'
 # mono
 nuget install Newtonsoft.Json

--- a/matmul/build.sh
+++ b/matmul/build.sh
@@ -1,9 +1,9 @@
 crystal build matmul.cr --release -o matmul_cr
 go build -o matmul_go matmul.go
 gccgo -O3 -g -o matmul_go_gccgo matmul.go
-gcc -O3 -o matmul_c matmul.c
+gcc -flto -O3 -o matmul_c matmul.c
 scalac -optimize matmul.scala
-rustc -C opt-level=3 matmul.rs -o matmul_rs
+rustc -C lto -C opt-level=3 matmul.rs -o matmul_rs
 dmd -ofmatmul_d -O -release -inline matmul.d
 gdc -o matmul_d_gdc -O3 -frelease -finline matmul.d
 ldc2 -ofmatmul_d_ldc -O5 -release -inline matmul.d


### PR DESCRIPTION
LTO was already enabled for Rust's JSON and base64.

Example speedups:

bench.b:
```
Cpp
ZYXWVUTSRQPONMLKJIHGFEDCBA
2.92s, 1.1Mb
Cpp LTO
ZYXWVUTSRQPONMLKJIHGFEDCBA
2.68s, 1.0Mb
Rust
ZYXWVUTSRQPONMLKJIHGFEDCBA
3.47s, 0.9Mb
Rust with LTO
ZYXWVUTSRQPONMLKJIHGFEDCBA
3.38s, 0.9Mb
```

mandel.b:
```
Cpp
31.93s, 2.0Mb
Cpp with LTO
23.17s, 1.8Mb
Rust
31.80s, 1.3Mb
Rust with LTO
32.58s, 1.3Mb
```