### PR TITLE
8x speedup for D matmul with Mir GLAS

### DIFF
--- a/matmul/build.sh
+++ b/matmul/build.sh
@@ -7,7 +7,7 @@ rustc -C opt-level=3 matmul.rs -o matmul_rs
 dmd -ofmatmul_d -O -release -inline matmul.d
 gdc -o matmul_d_gdc -O3 -frelease -finline matmul.d
 ldc2 -ofmatmul_d_ldc -O5 -release -inline matmul.d
-dub build --build=release-nobounds --single matmul/matmul_mir.d --compiler=ldmd2
+dub build --build=release-nobounds --single matmul_mir.d --compiler=ldmd2
 nim c -o:matmul_nim_gcc --cc:gcc -d:release --verbosity:0 matmul.nim
 nim c -o:matmul_nim_clang --cc:clang -d:release --verbosity:0 matmul.nim
 javac matmul.java

--- a/matmul/build.sh
+++ b/matmul/build.sh
@@ -7,6 +7,7 @@ rustc -C opt-level=3 matmul.rs -o matmul_rs
 dmd -ofmatmul_d -O -release -inline matmul.d
 gdc -o matmul_d_gdc -O3 -frelease -finline matmul.d
 ldc2 -ofmatmul_d_ldc -O5 -release -inline matmul.d
+dub build --build=release-nobounds --single matmul/matmul_mir.d --compiler=ldmd2
 nim c -o:matmul_nim_gcc --cc:gcc -d:release --verbosity:0 matmul.nim
 nim c -o:matmul_nim_clang --cc:clang -d:release --verbosity:0 matmul.nim
 javac matmul.java

--- a/matmul/matmul_mir.d
+++ b/matmul/matmul_mir.d
@@ -1,0 +1,57 @@
+#!/usr/bin/env dub
+/+ dub.json:
+{
+	"name": "matmul_d_mir",
+	"dependencies": {"mir": "~>0.16.0-beta2"},
+	"dflags-ldc": ["-mcpu=native"],
+}
++/
+//dub build --build=release-nobounds --single matmul/matmul_mir.d --compiler=ldmd2
+
+// Writen by Attractive Chaos; distributed under the MIT license
+
+import core.stdc.stdio, std.conv, std.array;
+import mir.ndslice;
+import mir.glas;
+
+alias Matrix = Slice!(2, double*);
+
+Matrix[2] generate2(size_t n)
+{
+	auto len = n * n;
+	double tmp = 1.0 / len;
+	auto ab = uninitializedArray!(double[])(len * 2).sliced(2, n, n);
+	auto a = ab[0];
+	auto b = ab[1];
+	size_t i;
+	foreach (row; assumeSameStructure!("a", "b")(a, b))
+	{
+		sizediff_t u = i, v = i;
+		foreach (x; row)
+		{
+			x.a = x.b = tmp * (u * v);
+			u--;
+			v++;
+		}
+		i++;
+	}
+	return [a, b];
+}
+
+Matrix mul(Matrix a, Matrix b)
+{
+	auto c = slice!double([a.length!0, b.length!1], 0);
+	auto ctx = new GlasContext;
+	ctx.gemm(c, 1.0, a, b);
+	return c;
+}
+
+void main(in string[] args)
+{
+	size_t n = 100;
+	if (args.length >= 2)
+		n = to!size_t(args[1]) / 2 * 2;
+	auto ab = generate2(n);
+	auto x = mul(ab[0], ab[1]);
+	printf("%.6f\n", x[n / 2, n / 2]);
+}

--- a/matmul/matmul_mir.d
+++ b/matmul/matmul_mir.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /+ dub.json:
 {
-	"name": "matmul_d_mir",
+	"name": "matmul_mir",
 	"dependencies": {"mir": "~>0.16.0-beta2"},
 	"dflags-ldc": ["-mcpu=native"],
 }

--- a/matmul/matmul_mir.d
+++ b/matmul/matmul_mir.d
@@ -6,7 +6,7 @@
 	"dflags-ldc": ["-mcpu=native"],
 }
 +/
-//dub build --build=release-nobounds --single matmul/matmul_mir.d --compiler=ldmd2
+//dub build --build=release-nobounds --single matmul_mir.d --compiler=ldmd2
 
 // Writen by Attractive Chaos; distributed under the MIT license
 

--- a/matmul/run.sh
+++ b/matmul/run.sh
@@ -14,6 +14,8 @@ echo D Gdc
 ../xtime.rb ./matmul_d_gdc 1500
 echo D Ldc
 ../xtime.rb ./matmul_d_ldc 1500
+echo D Mir GLAS
+../xtime.rb ./matmul_d_mir 1500
 echo Nim Gcc
 ../xtime.rb ./matmul_nim_gcc 1500
 echo Nim Clang


### PR DESCRIPTION
Mir  http://mir.dlang.io is written completely in D. No C/Fortran libraries like BLAS and no
assembler code are used.

Currently GLAS is single thread. As soon as I make it multithread it
will beat Julia :-)

Addition require [LDC >=1.1.0](https://github.com/ldc-developers/ldc/releases) and [D package
manager](http://code.dlang.org/download).