### PR TITLE
Add .Net Core tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ rock_tmp
 perllib
 *.jar
 .lein-deps-sum
+obj
+bin
+!project.json

--- a/base64/build.sh
+++ b/base64/build.sh
@@ -14,6 +14,7 @@ nim c -o:base64_nim_clang -d:release --cc:clang --verbosity:0 test.nim
 julia -e 'Pkg.add("Codecs")'
 cargo build --manifest-path base64.rs/Cargo.toml --release && cp ./base64.rs/target/release/base64 ./base64_rs
 mcs -debug- -optimize+ test.cs
+dotnet restore && dotnet build -c Release
 
 if [ ! -d aklomp-base64-ssse ]; then
   git clone --depth 1 https://github.com/aklomp/base64.git aklomp-base64-ssse

--- a/base64/clean.sh
+++ b/base64/clean.sh
@@ -8,3 +8,5 @@ rm -rf base64.rs/target
 rm -rf aklomp-base64*
 rm -rf perllib
 rm *.jar
+rm -rf bin/
+rm -rf obj/

--- a/base64/project.json
+++ b/base64/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "sources": {
+    "compile": "test.cs"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/base64/run.sh
+++ b/base64/run.sh
@@ -42,6 +42,8 @@ echo Ruby
 ../xtime.rb ruby test.rb
 echo Mono
 ../xtime.rb mono -O=all --gc=sgen test.exe
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/base64.dll
 echo Perl
 ../xtime.rb perl -Iperllib/lib/perl5 test.pl
 echo Perl XS

--- a/brainfuck/build.sh
+++ b/brainfuck/build.sh
@@ -10,6 +10,7 @@ ldc2 -ofbrainfuck_d_ldc -O5 -release -inline brainfuck.d
 nim c -o:brainfuck_nim_clang -d:release --cc:clang --verbosity:0 brainfuck.nim
 nim c -o:brainfuck_nim_gcc -d:release --cc:gcc --verbosity:0 brainfuck.nim
 mcs -debug- -optimize+ brainfuck.cs
+dotnet restore && dotnet build -c Release
 rock -o=brainfuck_ooc -v -O3 brainfuck.ooc
 flx --usage=hyperlight -c --static -o brainfuck_flx brainfuck.flx
 javac brainfuck.java

--- a/brainfuck/clean.sh
+++ b/brainfuck/clean.sh
@@ -4,3 +4,5 @@ rm *.o
 rm *.exe
 rm -rf .crystal
 rm -rf nimcache
+rm -rf bin/
+rm -rf obj/

--- a/brainfuck/project.json
+++ b/brainfuck/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "sources": {
+    "compile": "brainfuck.cs"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/brainfuck/run.sh
+++ b/brainfuck/run.sh
@@ -28,6 +28,8 @@ echo Julia
 ../xtime.rb julia brainfuck.jl bench.b
 echo Mono
 ../xtime.rb mono -O=all --gc=sgen brainfuck.exe bench.b
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/brainfuck.dll bench.b
 echo Python Pypy
 ../xtime.rb pypy brainfuck.py bench.b
 echo Python

--- a/brainfuck/run2.sh
+++ b/brainfuck/run2.sh
@@ -26,6 +26,8 @@ echo Python Pypy
 ../xtime.rb pypy brainfuck.py mandel.b > /dev/null
 echo Mono
 ../xtime.rb mono -O=all --gc=sgen brainfuck.exe mandel.b > /dev/null
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/brainfuck.dll mandel.b > /dev/null
 echo Felix
 ../xtime.rb ./brainfuck_flx mandel.b > /dev/null
 echo Java

--- a/brainfuck2/build.sh
+++ b/brainfuck2/build.sh
@@ -3,6 +3,7 @@ g++ -flto -O3 -o bin_cpp bf.cpp
 rustc -C opt-level=3 bf.rs -o bin_rs
 scalac -optimize bf.scala
 mcs -debug- -optimize+ bf.cs
+dotnet restore && dotnet build -c Release
 javac bf.java
 kotlinc bf2.kt -include-runtime -d bf2-kt.jar
 go build -o bin_go bf.go

--- a/brainfuck2/clean.sh
+++ b/brainfuck2/clean.sh
@@ -2,3 +2,5 @@ rm bin_*
 rm *.class
 rm *.exe
 rm *.jar
+rm -rf bin/
+rm -rf obj/

--- a/brainfuck2/project.json
+++ b/brainfuck2/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "sources": {
+    "compile": "bf.cs"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/brainfuck2/run.sh
+++ b/brainfuck2/run.sh
@@ -12,6 +12,8 @@ echo Kotlin
 ../xtime.rb java -jar bf2-kt.jar bench.b
 echo C# Mono
 ../xtime.rb mono -O=all --gc=sgen bf.exe bench.b
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/brainfuck2.dll bench.b
 echo Javascript V8
 ../xtime.rb d8 bf.d8.js
 echo Javascript Node

--- a/brainfuck2/run2.sh
+++ b/brainfuck2/run2.sh
@@ -28,6 +28,8 @@ echo Javascript Node
 ../xtime.rb node bf.js mandel.b > /dev/null
 echo C# Mono
 ../xtime.rb mono -O=all --gc=sgen bf.exe mandel.b > /dev/null
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/brainfuck2.dll mandel.b > /dev/null
 echo Python Pypy
 ../xtime.rb pypy bf.py mandel.b > /dev/null
 echo Ruby Topaz

--- a/havlak/build.sh
+++ b/havlak/build.sh
@@ -10,3 +10,4 @@ ldc2 -ofhavlak_d_ldc -O5 -release -inline havlak.d
 nim c -o:havlak_nim_gcc --cc:gcc -d:release --verbosity:0 havlak.nim
 nim c -o:havlak_nim_clang --cc:clang -d:release --verbosity:0 havlak.nim
 mcs -debug- -optimize+ havlak.cs
+dotnet restore && dotnet build -c Release

--- a/havlak/clean.sh
+++ b/havlak/clean.sh
@@ -4,3 +4,5 @@ rm *.o
 rm *.exe
 rm -rf .crystal
 rm -rf nimcache
+rm -rf bin/
+rm -rf obj/

--- a/havlak/project.json
+++ b/havlak/project.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "System.Collections": "4.0.11"
+  },
+  "sources": {
+    "compile": "havlak.cs"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/havlak/run.sh
+++ b/havlak/run.sh
@@ -24,3 +24,5 @@ echo Python
 ../xtime.rb python havlak.py
 echo Mono
 ../xtime.rb mono -O=all --gc=sgen havlak.exe
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/havlak.dll

--- a/json/build.sh
+++ b/json/build.sh
@@ -41,6 +41,9 @@ nuget install Newtonsoft.Json
 cp Newtonsoft.Json.*/lib/net45/Newtonsoft.Json.dll .
 mcs -debug- -optimize+ -r:Newtonsoft.Json.dll test.cs
 
+# .net core
+dotnet restore && dotnet build -c Release
+
 gem install yajl-ruby
 
 wget -qO - https://cpanmin.us | perl - -L perllib Cpanel::JSON::XS JSON::Tiny File::Slurper

--- a/json/clean.sh
+++ b/json/clean.sh
@@ -15,3 +15,5 @@ rm -rf perllib
 rm -rf json-clj/target
 rm json-clj/test.jar
 rm -rf json-java/target
+rm -rf bin/
+rm -rf obj/

--- a/json/project.json
+++ b/json/project.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "9.0.1"
+  },
+  "sources": {
+    "compile": "test.cs"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/json/run.sh
+++ b/json/run.sh
@@ -52,6 +52,8 @@ echo Julia
 ../xtime.rb julia test.jl
 echo Mono
 ../xtime.rb mono -O=all --gc=sgen test.exe
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/json.dll
 echo Ruby
 ../xtime.rb ruby test.rb
 echo Ruby YAJL

--- a/matmul/build.sh
+++ b/matmul/build.sh
@@ -13,6 +13,7 @@ nim c -o:matmul_nim_clang --cc:clang -d:release --verbosity:0 matmul.nim
 javac matmul.java
 kotlinc matmul.kt -include-runtime -d matmul-kt.jar
 mcs -debug- -optimize+ matmul.cs
+dotnet restore && dotnet build -c Release
 
 # numpy for matrix mult in python
 # brew install numpy

--- a/matmul/clean.sh
+++ b/matmul/clean.sh
@@ -5,3 +5,5 @@ rm *.exe
 rm -rf .crystal
 rm -rf nimcache
 rm *.jar
+rm -rf bin/
+rm -rf obj/

--- a/matmul/project.json
+++ b/matmul/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "sources": {
+    "compile": "matmul.cs"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/matmul/run.sh
+++ b/matmul/run.sh
@@ -38,6 +38,8 @@ echo Julia
 ../xtime.rb julia matmul.jl 1500
 echo Mono
 ../xtime.rb mono -O=all --gc=sgen matmul.exe 1500
+echo .Net Core
+../xtime.rb dotnet bin/Release/netcoreapp1.0/matmul.dll 1500
 echo Python Pypy
 ../xtime.rb pypy matmul.py 1500
 echo Python


### PR DESCRIPTION
Fixes #45
I tested it on Fedora 24.
On Ubuntu, you need to setup CLR as described here: https://www.microsoft.com/net/core#ubuntu

Ubuntu should be better supported. I had some problems with too new libicu (solved by https://github.com/dotnet/cli/issues/2018#issuecomment-233940514) and too new linux kernel (solved by https://github.com/dotnet/core/issues/172#issuecomment-233721107).

.Net Core SDK is still in v1.0.0-preview2-003121 opposite to just runtime (https://www.microsoft.com/net/download#core) and at least for me it does not work with base64 (null reference), matmul (works with smaller N) and havlak (segfault) otherwise it should work ok.