### PR TITLE
Use i32 instead of isize for brainfuck tape in Rust

### DIFF
--- a/brainfuck/brainfuck.rs
+++ b/brainfuck/brainfuck.rs
@@ -8,12 +8,12 @@ use std::collections::BTreeMap;
 
 struct Tape {
   pos: usize,
-  tape: Vec<isize>
+  tape: Vec<i32>
 }
 
 impl Tape {
   fn new() -> Tape { Tape { pos: 0, tape: vec![0] } }
-  fn get(&self) -> isize { self.tape[self.pos] }
+  fn get(&self) -> i32 { self.tape[self.pos] }
   fn getc(&self) -> char { self.get() as u8 as char }
   fn inc(&mut self) { self.tape[self.pos] += 1; }
   fn dec(&mut self) { self.tape[self.pos] -= 1; }

--- a/brainfuck2/bf.rs
+++ b/brainfuck2/bf.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 enum Op {
-    Inc(isize),
+    Inc(i32),
     Move(isize),
     Loop(Box<[Op]>),
     Print
@@ -10,14 +10,14 @@ use Op::*;
 
 struct Tape {
   pos: usize,
-  tape: Vec<isize>
+  tape: Vec<i32>
 }
 
 impl Tape {
   fn new() -> Tape { Tape { pos: 0, tape: vec![0] } }
-  fn get(&self) -> isize { self.tape[self.pos] }
+  fn get(&self) -> i32 { self.tape[self.pos] }
   fn getc(&self) -> char { self.get() as u8 as char }
-  fn inc(&mut self, x: isize) { self.tape[self.pos] += x; }
+  fn inc(&mut self, x: i32) { self.tape[self.pos] += x; }
   fn mov(&mut self, x: isize) { 
     self.pos = (self.pos as isize + x) as usize;
     while self.pos >= self.tape.len() { self.tape.push(0); }


### PR DESCRIPTION
This changes the Rust version to match the C++ version which uses `int` for its tape. `isize` is 64 bits on x86_64 while `int` is 32 bits.
