### PR TITLE
Implement BF2 benchmark in Tcl

### DIFF
--- a/brainfuck2/bf.tcl
+++ b/brainfuck2/bf.tcl
@@ -1,0 +1,63 @@
+package require Tcl 8.6
+
+namespace eval bf {
+    proc parse source {
+        set res {}
+        while 1 {
+            set c [lindex $source 0]
+            if {$c eq {}} break
+            set source [lrange $source 1 end]
+            switch -exact -- $c {
+                + { lappend res [list INC 1] }
+                - { lappend res [list INC -1] }
+                > { lappend res [list MOVE 1] }
+                < { lappend res [list MOVE -1] }
+                . { lappend res [list PRINT {}] }
+                \[ {
+                    lassign [parse $source] loop_code source
+                    lappend res [list LOOP $loop_code]
+                }
+                \] { break }
+                default {}
+            }
+        }
+        return [list $res $source]
+    }
+
+    proc run {program tape pos} {
+        foreach x $program {
+            lassign $x op val
+            switch -exact -- $op {
+                INC {
+                    lset tape $pos [expr {[lindex $tape $pos] + $val}]
+                }
+                MOVE {
+                    incr pos $val
+                    while {$pos >= [llength $tape]} {
+                        lappend tape 0
+                    }
+                }
+                PRINT {
+                    puts -nonewline [format %c [lindex $tape $pos]]
+                    flush stdout
+                }
+                LOOP {
+                    while {[lindex $tape $pos] > 0} {
+                        lassign [run $val $tape $pos] tape pos
+                    }
+                }
+            }
+        }
+        return [list $tape $pos]
+    }
+}   
+
+proc main argv {
+    lassign $argv filename
+    set f [open $filename]
+    lassign [::bf::parse [split [read $f] {}]] program
+    close $f
+    ::bf::run $program 0 0
+}
+
+main $argv

--- a/brainfuck2/bf_oo.tcl
+++ b/brainfuck2/bf_oo.tcl
@@ -1,0 +1,85 @@
+package require Tcl 8.6
+
+namespace eval bf {} {
+    ::oo::class create Tape {
+        variable tape pos
+        
+        constructor {} {
+            set tape 0
+            set pos 0
+        }
+        
+        method current {} {
+            return [lindex $tape $pos]
+        }
+        
+        method inc x {
+            lset tape $pos [expr {[lindex $tape $pos] + $x}]
+        }
+        
+        method move x {
+            incr pos $x
+            while {$pos >= [llength $tape]} {
+                lappend tape 0
+            }
+        }
+    }
+
+    proc parse source {
+        set res {}
+        while 1 {
+            set c [lindex $source 0]
+            if {$c eq {}} break
+            set source [lrange $source 1 end]
+            switch -exact -- $c {
+                + { lappend res [list INC 1] }
+                - { lappend res [list INC -1] }
+                > { lappend res [list MOVE 1] }
+                < { lappend res [list MOVE -1] }
+                . { lappend res [list PRINT {}] }
+                \[ {
+                    lassign [parse $source] loop_code source
+                    lappend res [list LOOP $loop_code]
+                }
+                \] { break }
+                default {}
+            }
+        }
+        return [list $res $source]
+    }
+
+    proc run {program tape} {
+        foreach x $program {
+            lassign $x op val
+            switch -exact -- $op {
+                INC {
+                    $tape inc $val
+                }
+                MOVE {
+                    $tape move $val
+                }
+                PRINT {
+                    puts -nonewline [format %c [$tape current]]
+                    flush stdout
+                }
+                LOOP {
+                    while {[$tape current] > 0} {
+                        run $val $tape
+                    }
+                }
+            }
+        }
+    }
+}   
+
+proc main argv {
+    lassign $argv filename
+    set f [open $filename]
+    lassign [::bf::parse [split [read $f] {}]] program
+    close $f
+    set tape [::bf::Tape new]
+    ::bf::run $program $tape
+    $tape destroy
+}
+
+main $argv

--- a/brainfuck2/run.sh
+++ b/brainfuck2/run.sh
@@ -44,3 +44,7 @@ echo Python
 ../xtime.rb python bf.py bench.b
 echo Python3
 ../xtime.rb python3 bf3.py bench.b
+echo Tcl (FP)
+../xtime.rb tclsh bf.tcl bench.b
+echo Tcl (OO)
+../xtime.rb tclsh bf_oo.tcl bench.b


### PR DESCRIPTION
This PR implements the brainfuck2 benchmark in Tcl — twice, actually. The first implementation, `bf.tcl`, is written in a functional style; it is faster and (IMO) more idiomatic Tcl, but it has the interpreter manipulate the tape directly. The second one, `bf_oo.tcl`, is object oriented and abstracts away the tape like the rest of the implementations do. Keep both or just one.

P.S.: It seems like all implementations of the benchmark abstract away the container underlying the tape with an function/method-based interface. Is this a de facto requirement? Perhaps the [README](https://github.com/kostya/benchmarks/blob/master/brainfuck2/README.md) should say something about it.