### PR TITLE
Update Java JSON to latest version

### DIFF
--- a/json/build.sh
+++ b/json/build.sh
@@ -59,7 +59,7 @@ pip install ujson
 pip3 install ujson
 
 # java
-cd json-java; mvn clean install; cp target/java-json-1.1-jar-with-dependencies.jar ../java-json.jar; cd ..
+cd json-java; mvn clean install; cp target/java-json-1.5-jar-with-dependencies.jar ../java-json.jar; cd ..
 
 #scala
 cd json-scala; sbt clean assembly; cp target/scala-2.11/benchmark-json-scala-assembly-1.0.jar ../scala-json.jar; cd ..

--- a/json/json-java/pom.xml
+++ b/json/json-java/pom.xml
@@ -6,18 +6,18 @@
 	<groupId>bench</groupId>
 	<artifactId>java-json</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1</version>
+	<version>1.5</version>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.dslplatform</groupId>
 			<artifactId>dsl-json</artifactId>
-			<version>1.1.2</version>
+			<version>1.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.dslplatform</groupId>
 			<artifactId>dsl-json-processor</artifactId>
-			<version>1.2</version>
+			<version>1.5.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/json/json-java/src/main/java/bench/TestJava.java
+++ b/json/json-java/src/main/java/bench/TestJava.java
@@ -18,7 +18,7 @@ public class TestJava {
 	public static void parse(String filename) throws IOException {
 		long start_time = System.currentTimeMillis();
 		FileInputStream fis = new FileInputStream(filename);
-		DslJson<Object> json = new DslJson<Object>();
+		DslJson<Object> json = new DslJson<Object>(new DslJson.Settings<Object>().includeServiceLoader().doublePrecision(JsonReader.DoublePrecision.LOW));
 		Root result = json.deserialize(Root.class, fis, new byte[65536]);
 		double x = 0, y = 0, z = 0;
 		int total = result.coordinates.size();


### PR DESCRIPTION
Explicitly set double parsing method to one comparable with previous one (they all provide the same result).