### PR TITLE
Rust: Remove useless stdout flushing

### DIFF
--- a/brainfuck2/bf.rs
+++ b/brainfuck2/bf.rs
@@ -32,10 +32,7 @@ fn _run(program: &[Op], tape: &mut Tape) {
             Loop(ref program) => while tape.get() > 0 {
               _run(program, tape);
             },
-            Print => {
-              print!("{}", tape.getc());
-              io::Write::flush(&mut io::stdout()).unwrap();
-            }
+            Print => print!("{}", tape.getc())
         }
     }
 }


### PR DESCRIPTION
Flushing is not mandatory here and I suppose Crystal do buffering to gain performances, so it is more fair to let Rust do automatic flushing to avoid too many system calls too (`stdout` flushing explicitly call `write` from the `libc`).