### PR TITLE
Go: Remove unnecessary "t.move(1)" in NewTape; add "default" case in parse

### DIFF
--- a/brainfuck2/bf.go
+++ b/brainfuck2/bf.go
@@ -53,7 +53,6 @@ type Tape struct {
 func NewTape() *Tape {
   t := &Tape{pos: 0}
   t.tape = make([]int, 1)
-  t.Move(1)
   return t
 }
 
@@ -96,6 +95,7 @@ func parse(si *StringIterator) []Op {
       case '[': op = NewOpLoop(LOOP, parse(si))
       case ']': return res
       case byte(0): return res
+      default: continue
     }
     res = append(res, op)
   }


### PR DESCRIPTION
Without a "default" case, parse was adding an extra op (inc 0) to the program whenever the input had a non-matching character