### PR TITLE
Add .as_a

### DIFF
--- a/json/test.cr
+++ b/json/test.cr
@@ -2,7 +2,7 @@ require "json"
 
 text = File.read("1.json")
 jobj = JSON.parse(text)
-coordinates = jobj["coordinates"]
+coordinates = jobj["coordinates"].as_a
 len = coordinates.size
 x = y = z = 0
 


### PR DESCRIPTION
Crystal 0.25.0 has breaking change for JSON::Any that require to include ```as_a```