### PR TITLE
Use monotonic clock in Ruby for more accurate time measurements

### DIFF
--- a/base64/test.rb
+++ b/base64/test.rb
@@ -7,16 +7,16 @@ str = "a" * STR_SIZE
 str2 = ""
 
 print "encode: "
-t, s = Time.now, 0
+t, s = Process.clock_gettime(Process::CLOCK_MONOTONIC), 0
 TRIES.times do |i|
   str2 = Base64.strict_encode64(str)
   s += str2.bytesize
 end
-puts "#{s}, #{Time.now - t}"
+puts "#{s}, #{Process.clock_gettime(Process::CLOCK_MONOTONIC) - t}"
 
 print "decode: "
-t, s = Time.now, 0
+t, s = Process.clock_gettime(Process::CLOCK_MONOTONIC), 0
 TRIES.times do |i|
   s += Base64.strict_decode64(str2).bytesize
 end
-puts "#{s}, #{Time.now - t}"
+puts "#{s}, #{Process.clock_gettime(Process::CLOCK_MONOTONIC) - t}"

--- a/repeat.rb
+++ b/repeat.rb
@@ -13,10 +13,10 @@ end
 
 min_t = nil
 10.times do
-  start = Time.now
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
   pid = Process.spawn(*ARGV.to_a)
   Process.waitall
-  t = Time.now - start
+  t = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
   min_t = t if min_t.nil? || t < min_t
   STDERR.puts "%.2fs" % t
 end

--- a/xtime.rb
+++ b/xtime.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 def mem(pid); `ps p #{pid} -o rss`.split.last.to_i; end
-t = Time.now
+t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 pid = Process.spawn(*ARGV.to_a)
 mm = 0
 
@@ -14,5 +14,5 @@ Thread.new do
 end
 
 Process.waitall
-STDERR.puts "%.2fs, %.1fMb" % [Time.now - t, mm / 1024.0]
+STDERR.puts "%.2fs, %.1fMb" % [Process.clock_gettime(Process::CLOCK_MONOTONIC) - t, mm / 1024.0]
 


### PR DESCRIPTION
### Overview
This PR changes all Ruby `Time.now` calls (wall clock), to `Process.clock_gettime(Process::CLOCK_MONOTONIC)` (monotonic clock) which is more appropriate for measuring time.

### Details
Ruby's `Time.now` uses `gettimeofday` or `clock_gettime` Linux functions from `time.h` which basically means that time does not always move forward and therefore in certain cases it might not give an accurate representation of elapsed time.

To solve this problem Posix systems have a monotonic clock which Ruby can access using `Process.clock_gettime(Process::CLOCK_MONOTONIC)`.

For more info: https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/