### PR TITLE
Greatly improve Java bf2 performance

### DIFF
--- a/brainfuck2/bf.java
+++ b/brainfuck2/bf.java
@@ -2,42 +2,43 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Stack;
 
-public class bf {
+public final class bf {
 
     public enum OpT {INC, MOVE, PRINT, LOOP}
 
-    public static class Op {
-        public OpT op;
-        public int v;
-        public List<Op> loop;
+    public static final class Op {
+        private static final Op[] NO_LOOP_OPS = new Op[0];
 
-        public Op(OpT _op, int _v) { op = _op; v = _v; loop = new ArrayList<Op>(); }
-        public Op(OpT _op, List<Op> _l) { op = _op; loop = _l; v = 0; }
+        public final OpT op;
+        public final int v;
+        public final Op[] loop;
+
+        public Op(final OpT _op, final int _v) { op = _op; v = _v; loop = NO_LOOP_OPS; }
+        public Op(final OpT _op, final Op[] _l) { op = _op; loop = _l; v = 0; }
     }
 
-    public static class CharacterIterator {
+    public static final class CharacterIterator {
         private final String str;
+        private final int strLen;
         private int pos = 0;
 
-        public CharacterIterator(String str) {
+        public CharacterIterator(final String str) {
             this.str = str;
+            strLen = str.length();
         }
 
         public boolean hasNext() {
-            return pos < str.length();
+            return pos < strLen;
         }
 
-        public Character next() {
+        public char next() {
             return str.charAt(pos++);
         }
     }
 
-    public static class Tape {
+    public static final class Tape {
         private int[] tape;
         private int pos;
 
@@ -49,31 +50,30 @@ public class bf {
             return tape[pos];
         }
 
-        public void inc(int x) {
+        public void inc(final int x) {
             tape[pos] += x;
         }
 
-        public void move(int x) {
+        public void move(final int x) {
             pos += x;
             while ( pos >= tape.length ) {
-                int[] tape = new int[this.tape.length * 2];
+                final int[] tape = new int[this.tape.length * 2];
                 System.arraycopy( this.tape, 0, tape, 0, this.tape.length );
                 this.tape = tape;
             }
-
         }
     }
 
-    public static class Program {
-        private List<Op> ops;
+    public static final class Program {
+        private final Op[] ops;
 
-        public Program(String code) {
+        public Program(final String code) {
             CharacterIterator it = new CharacterIterator(code);
             ops = parse(it);
         }
 
-        private List<Op> parse(CharacterIterator it) {
-            List<Op> res = new ArrayList<Op>();
+        private Op[] parse(final CharacterIterator it) {
+            final List<Op> res = new ArrayList<>();
             while (it.hasNext()) {
                 switch( it.next() ) {
                     case '+':
@@ -95,30 +95,29 @@ public class bf {
                         res.add(new Op(OpT.LOOP, parse(it)));
                         break;
                     case ']':
-                        return res;
+                        return res.toArray(new Op[res.size()]);
                 }
             }
-            return res;
+            return res.toArray(new Op[res.size()]);
         }
 
         public void run() {
             _run(ops, new Tape());
         }
 
-        private void _run(List<Op> program, Tape tape) {
-            for (Op op : program) {
+        private void _run(final Op[] program, final Tape tape) {
+            for (final Op op : program)
                 switch (op.op) {
                     case INC: tape.inc(op.v); break;
                     case MOVE: tape.move(op.v); break;
                     case LOOP: while (tape.get() > 0) _run(op.loop, tape); break;
                     case PRINT: System.out.print( (char) tape.get() ); break;
                 }
-            }
         }
     }
 
-    public static void main( String[] args ) throws IOException {
-        byte[] code = Files.readAllBytes( Paths.get( args[0] ) );
+    public static void main( final String[] args ) throws IOException {
+        final byte[] code = Files.readAllBytes( Paths.get( args[0] ) );
 
         long start_time = System.currentTimeMillis();
         System.err.println("warming");
@@ -127,9 +126,8 @@ public class bf {
 
         System.err.println("run");
         start_time = System.currentTimeMillis();
-        Program program = new Program(new String(code));
+        final Program program = new Program(new String(code));
         program.run();
         System.err.println("time: " + (System.currentTimeMillis()-start_time)/1e3+"s");
     }
 }
-


### PR DESCRIPTION
By doing some very simple changes to the existing Java implementation (using array instead of list, using final modifierers, avoiding Character/char autoboxing, reusing empty arrays) I can see a 100% performance improvement on my system using OpenJDK 8 and OpenJDK 11.
This version apparently also runs significantly faster than version offered via https://github.com/kostya/benchmarks/pull/173