### PR TITLE
nim: matmul uses less memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Intel(R) Core(TM) i5-2400 CPU @ 3.10GHz (Ubuntu 14.04.1 LTS x86_64)
 # Versions:
 
 * gcc (Ubuntu 4.8.2-19ubuntu1) 4.8.2
-* Nim Compiler Version 0.17.0 (2017-05-17) [Linux: amd64]
+* Nim Compiler Version 0.20.2
 * `Crystal 0.23.1 [e2a1389e8] (2017-07-13) LLVM 3.8.1`
 * go version go1.9 linux/amd64
 * gccgo (Ubuntu 4.9.1-0ubuntu1) 4.9.1

--- a/base64/build.sh
+++ b/base64/build.sh
@@ -9,8 +9,8 @@ kotlinc Test.kt -include-runtime -d Test-kt.jar
 dmd -ofbase64_d -O -release -inline test.d
 gdc -o base64_d_gdc -O3 -frelease -finline test.d
 ldc2 -ofbase64_d_ldc -O5 -release test.d
-nim c -o:base64_nim_gcc -d:release --cc:gcc --verbosity:0 test.nim
-nim c -o:base64_nim_clang -d:release --cc:clang --verbosity:0 test.nim
+nim c -o:base64_nim_gcc -d:danger --cc:gcc --verbosity:0 test.nim
+nim c -o:base64_nim_clang -d:danger --cc:clang --verbosity:0 test.nim
 julia -e 'Pkg.add("Codecs")'
 cargo build --manifest-path base64.rs/Cargo.toml --release && cp ./base64.rs/target/release/base64 ./base64_rs
 mcs -debug- -optimize+ test.cs

--- a/brainfuck/build.sh
+++ b/brainfuck/build.sh
@@ -7,8 +7,8 @@ rustc -C opt-level=3 brainfuck.rs -o brainfuck_rs
 dmd -ofbrainfuck_d -O -release -inline brainfuck.d
 gdc -o brainfuck_d_gdc -O3 -frelease -finline brainfuck.d
 ldc2 -ofbrainfuck_d_ldc -O5 -release -inline brainfuck.d
-nim c -o:brainfuck_nim_clang -d:release --cc:clang --verbosity:0 brainfuck.nim
-nim c -o:brainfuck_nim_gcc -d:release --cc:gcc --verbosity:0 brainfuck.nim
+nim c -o:brainfuck_nim_clang -d:danger --cc:clang --verbosity:0 brainfuck.nim
+nim c -o:brainfuck_nim_gcc -d:danger --cc:gcc --verbosity:0 brainfuck.nim
 mcs -debug- -optimize+ brainfuck.cs
 dotnet build -c Release
 rock -o=brainfuck_ooc -v -O3 brainfuck.ooc

--- a/brainfuck2/bf.nim
+++ b/brainfuck2/bf.nim
@@ -7,7 +7,7 @@ type
   OpT = enum
     INC = 1, MOVE = 2, LOOP = 3, PRINT = 4
 
-type 
+type
   Op = object
     op: OpT
     v: int
@@ -21,7 +21,7 @@ proc newOp(op1: OpT, l1: seq[Op]): Op =
   result.op = op1
   result.loop = l1
 
-type 
+type
   StringIterator = object
     text: string
     pos: int
@@ -58,7 +58,7 @@ type
   Program = object
     ops: seq[Op]
 
-proc parse(it: var StringIterator): seq[Op] = 
+proc parse(it: var StringIterator): seq[Op] =
   result = newSeq[Op]()
   while true:
     case it.next:
@@ -84,10 +84,9 @@ proc runops(program: seq[Op], tape: var Tape) =
       of LOOP:
         while tape.get > 0:
           runops(op.loop, tape)
-      of PRINT: 
+      of PRINT:
         write stdout, tape.get.chr
         flushFile(stdout)
-      else: discard
 
 proc run(self: Program) =
   var tape = newTape()

--- a/brainfuck2/build.sh
+++ b/brainfuck2/build.sh
@@ -11,8 +11,8 @@ gccgo -O3 -g -o bin_go_gccgo bf.go
 dmd -ofbin_d -O -release -inline bf.d
 gdc -o bin_d_gdc -O3 -frelease -finline bf.d
 ldc2 -ofbin_d_ldc -O5 -release bf.d
-nim c -o:bin_nim_clang -d:release --cc:clang --verbosity:0 bf.nim
-nim c -o:bin_nim_gcc -d:release --cc:gcc --verbosity:0 bf.nim
+nim c -o:bin_nim_clang -d:danger --cc:clang --verbosity:0 bf.nim
+nim c -o:bin_nim_gcc -d:danger --cc:gcc --verbosity:0 bf.nim
 stack ghc -- -O2 bf.hs -o bin_hs
 stack ghc -- -O2 bf-marray.hs -o bin_hs_marray
 ocamlopt bf.ml -o bin_ocaml

--- a/havlak/build.sh
+++ b/havlak/build.sh
@@ -6,7 +6,7 @@ scalac -optimize havlak.scala
 dmd -ofhavlak_d -O -release -inline havlak.d
 gdc -o havlak_d_gdc -O3 -frelease -finline havlak.d
 ldc2 -ofhavlak_d_ldc -O5 -release havlak.d
-nim c -o:havlak_nim_gcc --cc:gcc -d:release --verbosity:0 havlak.nim
-nim c -o:havlak_nim_clang --cc:clang -d:release --verbosity:0 havlak.nim
+nim c -o:havlak_nim_gcc --cc:gcc -d:danger --verbosity:0 havlak.nim
+nim c -o:havlak_nim_clang --cc:clang -d:danger --verbosity:0 havlak.nim
 mcs -debug- -optimize+ havlak.cs
 dotnet build -c Release

--- a/havlak/havlak.nim
+++ b/havlak/havlak.nim
@@ -1,5 +1,4 @@
 import tables
-import sequtils
 import sets
 
 type
@@ -233,7 +232,7 @@ proc findLoops(self: var HavlakLoopFinder): int =
   #     - the list of backedges (backPreds) or
   #     - the list of non-backedges (nonBackPreds)
   #
-  for w in 0 .. <size:
+  for w in 0 ..< size:
     header[w] = 0
     types[w]  = BB_NONHEADER
 
@@ -431,7 +430,7 @@ proc run(self: var LoopTesterApp) =
   var loops = h.findLoops
 
   echo "Another 50 iterations..."
- 
+
   var sum = 0
   for i in 1..50:
     write stdout, "."

--- a/json/build.sh
+++ b/json/build.sh
@@ -12,8 +12,8 @@ cargo build --manifest-path json.rs/Cargo.toml --release && \
 dmd -ofjson_d -O -release -inline test.d
 gdc -o json_d_gdc -O3 -frelease -finline test.d
 ldc2 -ofjson_d_ldc -O5 -release test.d
-nim c -o:json_nim_gcc -d:release --cc:gcc --verbosity:0 test.nim
-nim c -o:json_nim_clang -d:release --cc:clang --verbosity:0 test.nim
+nim c -o:json_nim_gcc -d:danger --cc:gcc --verbosity:0 test.nim
+nim c -o:json_nim_clang -d:danger --cc:clang --verbosity:0 test.nim
 go build -o json_go test.go
 gccgo -O3 -g -o json_go_gccgo test.go
 g++ -O3 test_boost.cpp -o json_boost_cpp

--- a/matmul/build.sh
+++ b/matmul/build.sh
@@ -8,8 +8,8 @@ dmd -ofmatmul_d -O -release -inline matmul.d
 gdc -o matmul_d_gdc -O3 -frelease -finline matmul.d
 ldc2 -ofmatmul_d_ldc -O5 -release matmul.d
 dub build --build=release --single matmul_d_mir.d --compiler=ldmd2
-nim c -o:matmul_nim_gcc --cc:gcc -d:release --verbosity:0 matmul.nim
-nim c -o:matmul_nim_clang --cc:clang -d:release --verbosity:0 matmul.nim
+nim c -o:matmul_nim_gcc --cc:gcc -d:danger --verbosity:0 matmul.nim
+nim c -o:matmul_nim_clang --cc:clang -d:danger --verbosity:0 matmul.nim
 javac matmul.java
 kotlinc matmul.kt -include-runtime -d matmul-kt.jar
 mcs -debug- -optimize+ matmul.cs

--- a/matmul/matmul.nim
+++ b/matmul/matmul.nim
@@ -1,20 +1,19 @@
 import os, strutils
 
 type
-  Matrix = seq[seq[float64]]
+  Matrix = seq[seq[float]]
 
 proc newmat(x: int, y: int): Matrix =
-  result = @[]
-  for i in 0..x-1:
-    result.add(@[])
-    for j in 0..y-1: result[i].add(0.0)
+  result.setLen x
+  for i in 0 ..< x:
+    result[i] = newSeq[float](y)
 
 proc matgen(n: int): Matrix =
   result = newmat(n, n)
-  let tmp = 1.0'f32 / float64(n) / float64(n)
-  for i in 0 .. <n:
-    for j in 0 .. <n:
-      result[i][j] = tmp * float64(i - j) * float64(i + j)
+  let tmp = 1.0 / float(n) / float(n)
+  for i in 0 ..< n:
+    for j in 0 ..< n:
+      result[i][j] = tmp * float(i - j) * float(i + j)
 
 proc matmul(a: Matrix, b: Matrix): Matrix =
   let m = a.len
@@ -23,19 +22,17 @@ proc matmul(a: Matrix, b: Matrix): Matrix =
 
   # transpose
   var b2 = newmat(n, p)
-  for i in 0 .. <n:
-    for j in 0 .. <p:
+  for i in 0 ..< n:
+    for j in 0 ..< p:
       b2[j][i] = b[i][j]
 
   # multiplication
   var c = newmat(m, p)
-  for i in 0 .. <m:
-   for j in 0 .. <p:
+  for i in 0 ..< m:
+   for j in 0 ..< p:
       var s = 0.0
-      let ai = a[i]
-      let b2j = b2[j]
-      for k in 0 .. <n:
-        s += ai[k] * b2j[k]
+      for k in 0 ..< n:
+        s += a[i][k] * b2[j][k]
       c[i][j] = s
   result = c
 


### PR DESCRIPTION
Updated the code to be compatible with the latest Nim version.

In Nim 0.20, `-d:danger` is what `-d:release` used to be: updated the build scripts accordingly.

-----

Results for `./xtime.rb ./matmul/matmul 1500` on my machine:
* old: `-143.50017; 3.85s, 120.9Mb`
* new: `-143.50017; 3.80s, 73.2Mb`