### PR TITLE
Base64 Zig test has been added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Some benchmarks of different languages
 | Nim Gcc         | 3.63    | 58.9        |
 | Scala           | 3.64    | 128.2       |
 | Go              | 3.65    | 178.5       |
+| Zig             | 3.70    | 31.9        |
 | V Gcc           | 3.77    | 2199.2      |
 | Go Gcc          | 4.47    | 219.1       |
 | C# .Net Core    | 4.70    | 224.4       |
@@ -284,3 +285,4 @@ Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz (Ubuntu 18.04.3 LTS x86_64)
 * Racket v6.11
 * Chez Scheme Version 9.5
 * V 0.1.21 c18578a
+* Zig 0.5.0+771dafbab

--- a/base64/build.sh
+++ b/base64/build.sh
@@ -27,3 +27,4 @@ gcc --std=c99 -O3 test-aklomp.c -I aklomp-base64-ssse/include/ aklomp-base64-sss
 wget -qO - https://cpanmin.us | perl - -L perllib MIME::Base64::Perl
 v -prod -cc gcc -o base64_v_gcc test.v
 v -prod -cc clang -o base64_v_clang test.v
+zig build-exe --release-fast --name base64_zig test.zig

--- a/base64/run.sh
+++ b/base64/run.sh
@@ -58,3 +58,5 @@ echo V Gcc
 ../xtime.rb ./base64_v_gcc
 echo V Clang
 ../xtime.rb ./base64_v_clang
+echo Zig
+../xtime.rb ./base64_zig

--- a/base64/test.zig
+++ b/base64/test.zig
@@ -1,0 +1,47 @@
+const std = @import("std");
+const time = std.time;
+const Timer = time.Timer;
+const allocator = std.heap.direct_allocator;
+
+const str_size = 10000000;
+const tries = 100;
+
+pub fn main() !void {
+    var stdout_file = try std.io.getStdOut();
+    const stdout = &stdout_file.outStream().stream;
+
+    const str1 = try allocator.alloc(u8, str_size);
+    defer allocator.free(str1);
+    std.mem.set(u8, str1, 'a');
+    var timer = try Timer.start();
+    var s: usize = 0;
+
+    var i: usize = 0;
+    var start = timer.lap();
+    while (i < tries) : (i += 1) {
+        const str2 = try allocator.alloc(u8, std.base64.Base64Encoder.calcSize(str1.len));
+        defer allocator.free(str2);
+        std.base64.standard_encoder.encode(str2, str1);
+        s += str2.len;
+    }
+    var end = timer.read();
+    var elapsed_s = @intToFloat(f64, end - start) / time.ns_per_s;
+    try stdout.print("encode: {}, {d:.2}\n", s, elapsed_s);
+
+    const str2 = try allocator.alloc(u8, std.base64.Base64Encoder.calcSize(str1.len));
+    defer allocator.free(str2);
+    std.base64.standard_encoder.encode(str2, str1);
+
+    i = 0;
+    s = 0;
+    start = timer.lap();
+    while (i < tries) : (i += 1) {
+        const str3 = try allocator.alloc(u8, try std.base64.standard_decoder.calcSize(str2));
+        defer allocator.free(str3);
+        try std.base64.standard_decoder.decode(str3, str2);
+        s += str3.len;
+    }
+    end = timer.read();
+    elapsed_s = @intToFloat(f64, end - start) / time.ns_per_s;
+    try stdout.print("decode: {}, {d:.2}\n", s, elapsed_s);
+}


### PR DESCRIPTION
Partially addressing #185. Used test.c as a reference except using standard base64 implementation within the Zig language. I've tried both 0.5.0 and the master version - no differences whatsover, hence I've decided to use the master version as it looks like that for non-stable releases we use the nightly builds (like for V).