### PR TITLE
Improve V base64 memory usage by using pre allocated buffers.

### DIFF
--- a/base64/test.v
+++ b/base64/test.v
@@ -7,28 +7,33 @@ fn main() {
 
   str := 'a'.repeat(str_size)
 
-  mut str2 := base64.encode(str)
+  str2 := base64.encode(str)
+  str3 := base64.decode(str2)
+  
+  str2_buffer := malloc( str2.len )
+  str3_buffer := malloc( str3.len )
+  
   print('encode ${str.substr(0, 4)}... to ${str2.substr(0, 4)}...: ')
 
   mut bench := benchmark.new_benchmark()
   bench.step()
   mut s := 0
   for i := 0; i < tries; i++ {
-    str2 = base64.encode(str)
-    s += str2.len
+    s += base64.encode_in_buffer(str, mut str2_buffer)
   }
   bench.ok()
   println(bench.step_message('$s'))
 
-  mut str3 := base64.decode(str2)
   print('decode ${str2.substr(0, 4)}... to ${str3.substr(0, 4)}...: ')
 
   bench.step()
   s = 0
-  for i := 0; i < tries; i++ {
-    str3 = base64.decode(str2)
-    s += str3.len
+  for i := 0; i < tries; i++ {    
+    s += base64.decode_in_buffer( str2, mut str3_buffer )
   }
   bench.ok()
-  println(bench.step_message('$s'))
+  println(bench.step_message('decode: $s'))
+  
+  bench.stop()
+  println(bench.total_message('running base64 encode/decode ops'))
 }


### PR DESCRIPTION
Before this PR, on my PC:
```shell
0[13:21:51] /v/benchmarks/base64 LINUX $ ###BEFORE
0[13:22:00] /v/benchmarks/base64 LINUX $ /v/nv/v -prod -cc gcc -o base64_v_gcc test.v
0[13:22:08] /v/benchmarks/base64 LINUX $ ../xtime.rb  ./base64_v_gcc
encode aaaa... to YWFh...:   1464 ms | 1431666688
decode YWFh... to aaaa...:   2278 ms | 1073741824
3.84s, 2397.9Mb
0[13:22:14] /v/benchmarks/base64 LINUX $
```

After this PR, on my PC:
```shell
0[13:22:25] /v/benchmarks/base64 LINUX $ ###AFTER
0[13:22:35] /v/benchmarks/base64 LINUX $ /v/nv/v -prod -cc gcc -o base64_v_gcc test.v
0[13:22:40] /v/benchmarks/base64 LINUX $ ../xtime.rb  ./base64_v_gcc
encode aaaa... to YWFh...:   1095 ms | 1431666688
decode YWFh... to aaaa...:   2009 ms | decode: 1073741824
  3104 ms | <=== total time spent running base64 encode/decode ops
 ok, fail, total =     2,     0,     2
3.11s, 2.0Mb
0[13:22:46] /v/benchmarks/base64 LINUX $
```
