### PR TITLE
Improve OCaml and F# versions

### DIFF
--- a/brainfuck2/bf.fs
+++ b/brainfuck2/bf.fs
@@ -51,9 +51,10 @@ let rec run program t =
       Console.Out.Flush()
       run ops t
   | Loop loop_code :: ops ->
-      if current t = 0 then run ops t
-      else
-        run loop_code t |> run program
+      let rec loop t =
+          if current t = 0 then run ops t
+          else run loop_code t |> loop
+      in loop t
 
 [<EntryPoint>]
 let main argv =

--- a/brainfuck2/bf.ml
+++ b/brainfuck2/bf.ml
@@ -47,10 +47,10 @@ let rec run program t =
       flush stdout;
       run ops t
   | Loop loop_code :: ops ->
-      if current t = 0 then run ops t
-      else
-        let  new_tape = run loop_code t in
-        run program new_tape
+     let rec loop t =
+       if current t = 0 then run ops t
+       else loop (run loop_code t)
+     in loop t
 
 let read_file filename =
   let s = ref "" in

--- a/brainfuck2/build.sh
+++ b/brainfuck2/build.sh
@@ -18,8 +18,8 @@ nim c -o:bin_nim_clang -d:danger --cc:clang --verbosity:0 bf.nim
 nim c -o:bin_nim_gcc -d:danger --cc:gcc --verbosity:0 bf.nim
 ghc -O2 -fforce-recomp bf.hs -o bin_hs
 ghc -O2 -fforce-recomp bf-marray.hs -o bin_hs_marray
-ocamlopt bf.ml -o bin_ocaml
-fsharpc bf.fs -o bin_fs.exe
+ocamlopt -unsafe bf.ml -o bin_ocaml
+fsharpc -O bf.fs -o bin_fs.exe
 mlton -output bin_sml bf.sml
 v -prod -cc gcc -o bin_v_gcc bf.v
 v -prod -cc clang -o bin_v_clang bf.v


### PR DESCRIPTION
This pull request fixes the interpretation of `loop` instruction in some functional versions to avoid repeatedly dispatching on the instruction, making it equivalent to imperative versions using `while`. This significantly speeds up F#.

It also turns on `-O` flag for F# and `-unsafe` for OCaml.