### PR TITLE
json: Use JSON3 in test.jl

### DIFF
--- a/json/build.sh
+++ b/json/build.sh
@@ -36,7 +36,7 @@ fi
 g++ -std=c++11 test_gason.cpp -I gason/src/ gason/src/gason.cpp -o json_gason_cpp -O3 -lsocket++
 
 g++ -O3 test_libjson.cpp -o json_libjson_cpp -ljson-c -lsocket++
-julia -e 'using Pkg; Pkg.add("JSON")'
+julia -e 'using Pkg; Pkg.add("JSON3")'
 # mono
 nuget install Newtonsoft.Json
 cp Newtonsoft.Json.*/lib/net45/Newtonsoft.Json.dll .

--- a/json/test.jl
+++ b/json/test.jl
@@ -2,10 +2,9 @@ import JSON3
 using Sockets
 
 function main()
-  text = open("1.json") do file
-    read(file, String)
+  jobj = open("1.json") do file
+    JSON3.read(file)
   end
-  jobj = JSON3.read(text)
   coordinates = jobj["coordinates"]
   len = length(coordinates)
   x = y = z = 0

--- a/json/test.jl
+++ b/json/test.jl
@@ -1,11 +1,11 @@
-import JSON
+import JSON3
 using Sockets
 
 function main()
   text = open("1.json") do file
     read(file, String)
   end
-  jobj = JSON.parse(text)
+  jobj = JSON3.read(text)
   coordinates = jobj["coordinates"]
   len = length(coordinates)
   x = y = z = 0


### PR DESCRIPTION
The `JSON` package used isn't part of the standard library, so maybe it's fair
to replace it with the newer package by the same author?

On my machine, `JSON3` is over twice as fast and uses much less memory.