### PR TITLE
Fix logging on machines without energy stats

### DIFF
--- a/xtime.rb
+++ b/xtime.rb
@@ -76,5 +76,10 @@ if energy_stats.has_energy_metrics
   open('results.log', 'a') { |f|
     f.puts "%s\t%f\t%f\t%f" % [test_name, t_diff, mm_mb, energy_stats.val]
   }
+else
+  stats += ", 0.0 J"
+  open('results.log', 'a') { |f| 
+    f.puts "%s\t%f\t%f\t0.0" % [test_name, t_diff, mm_mb]
+  }  
 end
 STDERR.puts stats


### PR DESCRIPTION
results.log will not be updated/created on machines without energy stats without this.  This allows hosts like MacOS to run the run analyze.rb