### PR TITLE
Use Unmarshal for Go

### DIFF
--- a/json/test.go
+++ b/json/test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"runtime"
-	"strings"
 )
 
 type Coordinate struct {
@@ -31,16 +30,11 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("%v", err))
 	}
-	content := string(bytes)
-	reader := strings.NewReader(content)
 
 	notify(fmt.Sprintf("%s\t%d", runtime.Compiler, os.Getpid()))
 
 	jobj := TestStruct{}
-	err = json.NewDecoder(reader).Decode(&jobj)
-	if err != nil {
-		panic(err)
-	}
+        json.Unmarshal(bytes, &jobj)
 
 	x, y, z := 0.0, 0.0, 0.0
 

--- a/json/test.go
+++ b/json/test.go
@@ -34,7 +34,7 @@ func main() {
 	notify(fmt.Sprintf("%s\t%d", runtime.Compiler, os.Getpid()))
 
 	jobj := TestStruct{}
-        json.Unmarshal(bytes, &jobj)
+	json.Unmarshal(bytes, &jobj)
 
 	x, y, z := 0.0, 0.0, 0.0
 


### PR DESCRIPTION
Remove the conversion to string part, it can read json file into struct, result in less code.

Original:
Memory: <411MB
Time: 1.95s

New Code:
Memory: 215MB
Time: 1.7s