### PR TITLE
Compile Chez program

### DIFF
--- a/brainfuck2/bf.ss
+++ b/brainfuck2/bf.ss
@@ -1,3 +1,5 @@
+(import (chezscheme))
+
 (define-record-type op (fields op val))
 (define-record-type tape (fields data pos))
 

--- a/brainfuck2/run.sh
+++ b/brainfuck2/run.sh
@@ -72,7 +72,7 @@ echo "Tcl (OO)"
 echo Racket
 ../xtime.rb racket bf.rkt bench.b
 echo Chez Scheme
-../xtime.rb scheme --script bf.ss bench.b
+../xtime.rb scheme --optimize-level 3 --program bf.ss bench.b
 echo V Gcc
 ../xtime.rb ./bin_v_gcc bench.b
 echo V Clang

--- a/brainfuck2/run2.sh
+++ b/brainfuck2/run2.sh
@@ -52,7 +52,7 @@ echo LuaJIT
 echo Racket
 ../xtime.rb racket bf.rkt mandel.b > /dev/null
 echo Chez Scheme
-../xtime.rb scheme --script bf.ss mandel.b > /dev/null
+../xtime.rb scheme --optimize-level 3 --program bf.ss mandel.b > /dev/null
 echo V Gcc
 ../xtime.rb ./bin_v_gcc mandel.b > /dev/null
 echo V Clang


### PR DESCRIPTION
Before the benchmark was comparing interpreted Chez speed, but Chez is mainly known for being a Scheme compiler :)

There's actually a way to make a standalone dynamic binary but it's a bit more complicated (and I'm not really experienced with Chez) 

Also used `--optimize-level 3` for max optimizations

On my machine performance for `bench.b` improved roughly 5 times, and ~4 times for `mandel.b`