### PR TITLE
Switch the simdjson code to On Demand

### DIFF
--- a/common/commands.mk
+++ b/common/commands.mk
@@ -1,4 +1,4 @@
-GCC_FLAGS := -O3 -Wall -flto -Wa,-mbranches-within-32B-boundaries
+GCC_FLAGS := -O3 -march=native -Wall -flto -Wa,-mbranches-within-32B-boundaries
 CLANG_FLAGS := -O3 -mbranches-within-32B-boundaries
 LIBNOTIFY_FLAGS := -I../common/libnotify ../common/libnotify/target/libnotify.a
 NIM_FLAGS := -d:danger --verbosity:0 --opt:speed --hints:off

--- a/json/Makefile
+++ b/json/Makefile
@@ -179,9 +179,12 @@ json-scala/target/application.jar:
 	$(MAKE) -C json-scala target/application.jar
 
 simdjson-dir := target/simdjson
+
+# We specify the simdjson commit to ensure reproducible builds.
 $(simdjson-dir): | target
 	$(GIT_CLONE) "https://github.com/simdjson/simdjson.git" $@ \
 	&& cd $@/singleheader \
+	&& git checkout bb2bc98a22b68471f193a3f3a60effd9d15183e2 \
 	&& ./amalgamate.sh
 
 target/json_simdjson_cpp: test_simdjson.cpp | $(simdjson-dir) libnotify

--- a/json/Makefile
+++ b/json/Makefile
@@ -185,7 +185,7 @@ $(simdjson-dir): | target
 	&& ./amalgamate.sh
 
 target/json_simdjson_cpp: test_simdjson.cpp | $(simdjson-dir) libnotify
-	$(GCC_CPP_BUILD) $(simdjson-dir)/singleheader/simdjson.cpp \
+	$(GCC_CPP_BUILD) -march=native $(simdjson-dir)/singleheader/simdjson.cpp \
 		-I$(simdjson-dir)/singleheader/
 
 target/json_v_gcc: test.v | $(v_fmt)

--- a/json/Makefile
+++ b/json/Makefile
@@ -180,15 +180,13 @@ json-scala/target/application.jar:
 
 simdjson-dir := target/simdjson
 
-# We specify the simdjson commit to ensure reproducible builds.
 $(simdjson-dir): | target
 	$(GIT_CLONE) "https://github.com/simdjson/simdjson.git" $@ \
 	&& cd $@/singleheader \
-	&& git checkout bb2bc98a22b68471f193a3f3a60effd9d15183e2 \
 	&& ./amalgamate.sh
 
 target/json_simdjson_cpp: test_simdjson.cpp | $(simdjson-dir) libnotify
-	$(GCC_CPP_BUILD) -march=native $(simdjson-dir)/singleheader/simdjson.cpp \
+	$(GCC_CPP_BUILD) $(simdjson-dir)/singleheader/simdjson.cpp \
 		-I$(simdjson-dir)/singleheader/
 
 target/json_v_gcc: test.v | $(v_fmt)

--- a/json/test_simdjson.cpp
+++ b/json/test_simdjson.cpp
@@ -58,7 +58,7 @@ coordinate_t calc(const simdjson::padded_string& json) {
 }
 
 int main() {
-  auto left = calc("{\"coordinates\":[{\"x\":1.1,\"y\":2.2,\"z\":3.3}]}"_padded);
+  auto left = calc("{\"coordinates\":[{\"x\":1.1,\"y\":2.2,\"z\":3.3}]}"_padded); // The _padded suffix creates a simdjson::padded_string instance
   auto right = coordinate_t(1.1, 2.2, 3.3);
   if (left != right) {
     cerr << left << " != " << right << endl;

--- a/json/test_simdjson.cpp
+++ b/json/test_simdjson.cpp
@@ -61,11 +61,11 @@ int main() {
   auto left = calc("{\"coordinates\":[{\"x\":1.1,\"y\":2.2,\"z\":3.3}]}"_padded);
   auto right = coordinate_t(1.1, 2.2, 3.3);
   if (left != right) {
-    std::cerr << left << " != " << right << std::endl;
+    cerr << left << " != " << right << endl;
     exit(EXIT_FAILURE);
   }
   auto [text, error] = simdjson::padded_string::load("/tmp/1.json");
-  if(error) { std::cerr << "could not load file" << std::endl; return EXIT_FAILURE; }
+  if(error) { cerr << "could not load file" << endl; return EXIT_FAILURE; }
   stringstream ostr;
   ostr << "C++/g++ (simdjson)\t" << getpid();
   notify(ostr.str());

--- a/json/test_simdjson.cpp
+++ b/json/test_simdjson.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 #include <libnotify.hpp>
-#include "simdjson.h"
 #include <sstream>
 #include <unistd.h>
 #include <fstream>
 
-using namespace simdjson;
+#include "simdjson.h"
+
 using namespace std;
 
 struct coordinate_t {
@@ -23,63 +23,52 @@ struct coordinate_t {
   }
 };
 
-string read_file(const string& filename) {
-  ifstream f(filename);
-  if (!f) {
-    return {};
+
+using namespace simdjson;
+using namespace simdjson::builtin;
+
+class on_demand {
+public:
+  bool run(const padded_string &json);
+  coordinate_t my_point{};
+  size_t count{};
+private:
+  ondemand::parser parser{};
+};
+
+bool on_demand::run(const padded_string &json) {
+  count = 0;
+  auto doc = parser.iterate(json);
+  for (ondemand::object point_object : doc["coordinates"]) {
+    my_point.x += double(point_object["x"]);
+    my_point.y += double(point_object["y"]);
+    my_point.z += double(point_object["z"]);
+    count++;
   }
-  return string(istreambuf_iterator<char>(f),
-                istreambuf_iterator<char>());
+  return true;
 }
 
-coordinate_t calc(const string& text) {
-  dom::parser pj(0);
-  auto allocate_error = pj.allocate(text.size()); // allocate memory for parsing up to p.size() bytes
-  if (allocate_error) {
-    cerr << allocate_error << endl;
-    exit(EXIT_FAILURE);
-  }
-
-  auto [doc, error] = pj.parse(text); // do the parsing, return 0 on success
-  if (error) {
-    cerr << error << endl;
-    exit(EXIT_FAILURE);
-  }
-
-  auto x = 0.0, y = 0.0, z = 0.0;
-  auto len = 0;
-
-  for (auto coord : doc["coordinates"]) {
-    double x_coord = coord["x"];
-    x += x_coord;
-
-    double y_coord = coord["y"];
-    y += y_coord;
-
-    double z_coord = coord["z"];
-    z += z_coord;
-
-    len++;
-  }
-
-  return coordinate_t(x / len, y / len, z / len);
+coordinate_t calc(const simdjson::padded_string& json) {
+  on_demand reader;
+  reader.run(json);
+  reader.my_point.x /= reader.count;
+  reader.my_point.y /= reader.count;
+  reader.my_point.z /= reader.count;
+  return reader.my_point;
 }
 
 int main() {
-  auto left = calc("{\"coordinates\":[{\"x\":1.1,\"y\":2.2,\"z\":3.3}]}");
+  auto left = calc("{\"coordinates\":[{\"x\":1.1,\"y\":2.2,\"z\":3.3}]}"_padded);
   auto right = coordinate_t(1.1, 2.2, 3.3);
   if (left != right) {
-    cerr << left << " != " << right << endl;
+    std::cerr << left << " != " << right << std::endl;
     exit(EXIT_FAILURE);
   }
-
-  auto text = read_file("/tmp/1.json");
-
+  auto [text, error] = simdjson::padded_string::load("/tmp/1.json");
+  if(error) { std::cerr << "could not load file" << std::endl; return EXIT_FAILURE; }
   stringstream ostr;
   ostr << "C++/g++ (simdjson)\t" << getpid();
   notify(ostr.str());
-
   cout << calc(text) << endl;
-
   notify("stop");
 }


### PR DESCRIPTION
The simdjson library is already included in the kostya/benchmarks repository. However, the simdjson library can be run in two modes: the DOM API and the On Demand API. The DOM API is currently used in kostya/benchmarks. However, it is not a scenario that is favorable to a DOM API since it is clearly unnecessary to build a DOM to satisfy the benchmark. The On Demand API is better suited. Thus this PR switches the code from the DOM API to the On Demand API. We expect better performance. Furthermore, while at it, we tweaked the Makefile so that it checks out a specific commit from the simdjson repository, thus ensuring that no matter what happens upstream, code won't break in kostya/benchmarks.

Credit to @jkeiser 