### PR TITLE
Lua perf boost

### DIFF
--- a/brainfuck/bf.lua
+++ b/brainfuck/bf.lua
@@ -1,111 +1,113 @@
-local INC = 0
-local MOVE = 1
-local PRINT = 3
-local LOOP = 4
+local specialInstruction = {
+	["."] = "w(data[i])",
+	[","] = "data[i]=r()",
+	["["] = "while data[i]~=0 do ",
+	["]"] = "end "
+}
 
-local function Tape()
-  local pos = 1;
-  local data = {0};
+local artithmeticsIns = {
+	["+"] = "data[i] = data[i]+",
+	["-"] = "data[i] = data[i]-",
+	[">"] = "i=i+",
+	["<"] = "i=i-"
+}
 
-  local get = function()
-    return data[pos];
-  end
+local brainfuck = function(s)
+	s = s:gsub("[^%+%-<>%.,%[%]]+", "") -- remove new lines
+	local instList = {}
+	local slen = #s
+	local i = 2
+	local lastInstruction = s:sub(1, 1)
+	local arithmeticsCount = 0
 
-  local inc = function(x)
-    data[pos] = data[pos] + x;
-  end
+	if (artithmeticsIns[lastInstruction]) then
+		arithmeticsCount = 1
+	end
 
-  local move = function(x)
-    local length = #data;
-    pos = pos + x;
-    for i = length + 1, pos do
-      data[i] = 0;
-    end
-  end
+	while (i <= slen) do
+		local curInst = s:sub(i, i)
 
-  return {
-    get = get;
-    inc = inc;
-    move = move;
-  };
+		if curInst == lastInstruction then
+			if artithmeticsIns[curInst] then
+				arithmeticsCount = arithmeticsCount + 1
+			else
+				table.insert(instList, specialInstruction[curInst])
+			end
+		else
+			if artithmeticsIns[lastInstruction] then
+				table.insert(instList, artithmeticsIns[lastInstruction] .. arithmeticsCount .. ' ')
+
+				if artithmeticsIns[curInst] then
+					arithmeticsCount = 1
+				else
+					table.insert(instList, specialInstruction[curInst])
+					arithmeticsCount = 0
+				end
+			else
+				if artithmeticsIns[curInst] then
+					arithmeticsCount = 1
+				else
+					table.insert(instList, specialInstruction[curInst])
+					arithmeticsCount = 0
+				end
+			end
+		end
+
+		lastInstruction = curInst
+		i = i + 1
+	end
+
+	local code = [[local data;
+if type(rawget(_G, "jit")) == 'table' then
+	local ffi = require("ffi")
+	data = ffi.new("int[1024]")
+else
+	data = {}
+	local i = 0
+	while i < 1024 do
+		data[i] = 0
+		i = i + 1
+	end
+end
+local i = 0
+
+local w = function(c)
+	io.write(string.char(c))
 end
 
-local function Brainfuck(text)
-  local function parse(source, i)
-    local res = {};
-    while i <= source:len() do
-      local c = source:sub(i, i);
-      if c == "+" then
-        table.insert(res, {INC, 1});
-      elseif c == "-" then
-        table.insert(res, {INC, -1});
-      elseif c == ">" then
-        table.insert(res, {MOVE, 1});
-      elseif c == "<" then
-        table.insert(res, {MOVE, -1});
-      elseif c == "." then
-        table.insert(res, {PRINT});
-      elseif c == "[" then
-        local loop_code;
-        loop_code, i = parse(source, i+1);
-        table.insert(res, {LOOP, loop_code});
-      elseif c == "]" then
-        break;
-      end
-      i = i + 1;
-    end
-    return res, i;
-  end
+local r = function()
+	return io.read(1):byte()
+end
 
-  local function _run(program, tape)
-    for i = 1, #program do
-      local op = program[i];
-      local operator = op[1];
-      if operator == INC then
-        tape.inc(op[2]);
-      elseif operator == MOVE then
-        tape.move(op[2]);
-      elseif operator == LOOP then
-        while tape.get() > 0 do
-          _run(op[2], tape);
-        end
-      elseif operator == PRINT then
-        io.write(string.char(tape.get()));
-        io.flush();
-      end
-    end
-  end
+]] .. table.concat(instList)
+	local loadstring = loadstring or load
 
-  local function run()
-    _run(parse(text, 1), Tape())
-  end
-
-  return {
-    run = run;
-  };
+	return loadstring(code, "brainfuck", "t")
 end
 
 local function notify(msg)
-  local socket = require "socket"
-  socket.protect(function()
-    local c = socket.try(socket.connect("localhost", 9001))
-    local try = socket.newtry(function() c:close() end)
-    try(c:send(msg))
-    c:close()
-  end)()
+	local socket = require"socket"
+
+	socket.protect(function()
+		local c = socket.try(socket.connect("localhost", 9001))
+
+		local try = socket.newtry(function()
+			c:close()
+		end)
+
+		try(c:send(msg))
+		c:close()
+	end)()
 end
 
 (function(arg)
-  local f = io.open(arg[1])
-  local text = f:read("*a")
-  f:close()
-
-  local compiler = type(jit) == 'table' and "Lua/luajit" or "Lua"
-  local getpid = require 'posix.unistd'.getpid
-  notify(string.format("%s\t%d", compiler, getpid()))
-
-  local brainfuck = Brainfuck(text)
-  brainfuck.run()
-
-  notify("stop")
+	local f = io.open(arg[1])
+	local text = f:read("*a")
+	f:close()
+	local compiler = type(jit) == 'table' and "Lua/luajit" or "Lua"
+	local getpid = require'posix.unistd'.getpid
+	notify(string.format("%s\t%d", compiler, getpid()))
+	local brainfuckFunc = brainfuck(text)
+	brainfuckFunc()
+	notify("stop")
 end)(arg)


### PR DESCRIPTION
Compatible with LuaJIT (using FFI structs), Lua 5.1 and Lua 5.4

Performance change compared to [brainfuck interpreter](https://github.com/kostya/benchmarks/blob/master/brainfuck/bf.lua)



LuaJIT :

	mandelbrot -> ran in 53.81s -> ran in 2.183s

	bench -> ran in 8.25s -> ran in 0.183s

**2364.96%** and **4408.2%** perf boost



Lua 51 : 

	bench -> ran in 98.926s -> ran in 14.042s

**604.5% perf boost**


Lua 54 :

	bench -> ran in 51.345s -> ran in 4.858s

**956.92%** perf boost


LuaJIT goes BRRRRRRR