### PR TITLE
Add compact attribute for hot classes

### DIFF
--- a/brainfuck/bf.vala
+++ b/brainfuck/bf.vala
@@ -35,25 +35,27 @@ namespace Test {
         public Op.vnull(OpT _op, Op[] _l) { op = _op; loop = _l; v = 0; }
     }
 
+    [Compact]
     class Tape {
-        private int pos = 0;
-        private int[] tape = new int[1];
+        public int pos = 0;
+        public int[] tape = new int[1];
 
-        public int Get() { return tape[pos]; }
-        public void Inc(int x) { tape[pos] += x; }
-        public void Move(int x) { pos += x; while (pos >= tape.length) tape.resize(tape.length*2);}
+        public inline int Get() { return tape[pos]; }
+        public inline void Inc(int x) { tape[pos] += x; }
+        public inline void Move(int x) { pos += x; while (pos >= tape.length) tape.resize(tape.length*2);}
     }
 
+    [Compact]
     class Printer {
-        private int sum1 = 0;
-        private int sum2 = 0;
+        public int sum1 = 0;
+        public int sum2 = 0;
         public bool quiet;
 
         public Printer(bool quiet) {
             this.quiet = quiet;
         }
 
-        public void print(int n) {
+        public inline void print(int n) {
             if (quiet) {
                 sum1 = (sum1 + n) % 255;
                 sum2 = (sum2 + sum1) % 255;
@@ -74,7 +76,7 @@ namespace Test {
         private string code;
         private int pos = 0;
         private Op[] ops;
-        private Printer p;
+        private unowned Printer p;
 
         Program(string text, Printer p) {
             code = text;

--- a/brainfuck/bf.vala
+++ b/brainfuck/bf.vala
@@ -60,7 +60,7 @@ namespace Test {
                 sum1 = (sum1 + n) % 255;
                 sum2 = (sum2 + sum1) % 255;
             } else {
-                stdout.printf("%c", (char)n);
+                stdout.putc((char)n);
                 stdout.flush();
             }
         }


### PR DESCRIPTION
Vala lost 10 seconds, which at first surprised me, then I looked in db679b031712e9da8ac72f56b2d5d000b4b88c3d and after experiments, I found that the reason was private fields. I created an issue https://gitlab.gnome.org/GNOME/vala/-/issues/1116.  
The maintainer of the language recommends the use of a Compact classes in high loaded code. Also Vala supports inline modifier, so I added it on hot methods too. 