### PR TITLE
Add Racket BF variant that uses syntax objects and `eval`

### DIFF
--- a/brainfuck/Makefile
+++ b/brainfuck/Makefile
@@ -232,6 +232,9 @@ run[bf_oo.tcl]:: run[%]: %
 run[bf.rkt]:: run[%]: %
 	$(RACKET_RUN) $(BF_SRC)
 
+run[bf-syntax.rkt]:: run[%]: %
+	$(RACKET_RUN) $(BF_SRC)
+
 run[bf.ss]:: run[%]: % | libnotify
 	$(SCHEME_RUN) $(BF_SRC)
 

--- a/brainfuck/bf-syntax.rkt
+++ b/brainfuck/bf-syntax.rkt
@@ -117,7 +117,7 @@
   (define text (read-c (command-line #:args (filename) filename)))
   (define p (printer 0 0 (getenv "QUIET")))
 
-  (notify (format "Racket\t~s" (getpid)))
+  (notify (format "Racket (Syntax Objects)\t~s" (getpid)))
   (time (run (parse text) (tape (vector 0) 0) p))
   (notify "stop")
 

--- a/brainfuck/bf-syntax.rkt
+++ b/brainfuck/bf-syntax.rkt
@@ -1,0 +1,124 @@
+#lang racket/base
+
+(require racket/file racket/list racket/match racket/cmdline racket/os racket/tcp
+         (rename-in racket/unsafe/ops
+                    [unsafe-vector-ref vector-ref]
+                    [unsafe-vector-set! vector-set!]
+                    [unsafe-fx+ +]))
+
+(struct tape ([data #:mutable] [pos #:mutable]))
+
+;;; Printer.
+
+(struct printer ([sum1 #:mutable] [sum2 #:mutable] quiet))
+
+(define (print p n)
+  (if (printer-quiet p)
+      (begin
+          (set-printer-sum1! p (remainder
+                                (+ (printer-sum1 p) n)
+                                255))
+          (set-printer-sum2! p (remainder
+                                (+ (printer-sum2 p) (printer-sum1 p))
+                                255)))
+      (begin
+          (display (integer->char n))
+          (flush-output))))
+
+(define (get-checksum p)
+  (bitwise-ior (arithmetic-shift (printer-sum2 p) 8) (printer-sum1 p)))
+
+;;; Vector and tape ops.
+
+(define (vector-grow-if-needed vec len)
+  (define old-len (vector-length vec))
+  (cond [(< len old-len) vec]
+        [else
+         (let loop ([new-len (* 2 old-len)])
+           (cond [(>= len new-len) (loop (* 2 new-len))]
+                 [else (define new-vec (make-vector new-len))
+                       (vector-copy! new-vec 0 vec)
+                       new-vec]))]))
+
+(define (tape-get t)
+  (vector-ref (tape-data t) (tape-pos t)))
+
+(define (tape-move! t n)
+  (let ([new-pos (+ n (tape-pos t))])
+    (set-tape-data! t (vector-grow-if-needed (tape-data t) new-pos))
+    (set-tape-pos! t new-pos)))
+
+(define (tape-inc! t n)
+  (let ((data (tape-data t)) (pos (tape-pos t)))
+    (vector-set! data pos (+ n (vector-ref data pos)))))
+
+;;; Parser.
+
+(define (parse-helper lst acc)
+  (if (empty? lst)
+      (reverse acc)
+      (let ([rst (rest lst)])
+        (match (first lst)
+          [#\+ (parse-helper rst (cons (inc 1) acc))]
+          [#\- (parse-helper rst (cons (inc -1) acc))]
+          [#\> (parse-helper rst (cons (move 1) acc))]
+          [#\< (parse-helper rst (cons (move -1) acc))]
+          [#\. (parse-helper rst (cons -print acc))]
+          [#\[ (let ([subparsed (parse-helper rst empty)])
+                 (parse-helper (first subparsed)
+                               (cons (loop (rest subparsed)) acc)))]
+          [#\] (cons rst (reverse acc))]
+          [_ (parse-helper rst acc)]))))
+
+(define (parse bf-code) (parse-helper (string->list bf-code) empty))
+
+;;; Interpreter.
+
+(define ((inc x) t p) #`(tape-inc! #,t #,x))
+(define ((move x) t p) #`(tape-move! #,t #,x))
+(define (-print t p) #`(print #,p (tape-get #,t)))
+(define ((loop ops) t p)
+  #`(let go ()
+      (when (> (tape-get #,t) 0)
+        #,@(map (λ (op) (op t p)) ops)
+        (go))))
+
+(define (run parsed t p)
+  ((eval #`(λ (t p) #,@(map (λ (op) (op #'t #'p)) parsed))) t p))
+
+(define (notify msg)
+  (with-handlers ([exn:fail:network? (lambda (_) (void))])
+    (let-values ([(in out) (tcp-connect "localhost" 9001)])
+      (display msg out)
+        (close-output-port out))))
+
+(define (read-c path)
+  (parameterize ([current-locale "C"])
+    (file->string path)))
+
+(define (verify)
+  (define text "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>\
+---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.")
+  (define p-left (printer 0 0 #t))
+  (define p-right (printer 0 0 #t))
+
+  (run (parse text) (tape (vector 0) 0) p-left)
+  (for-each
+   (lambda (c) (print p-right (char->integer c)))
+   (string->list "Hello World!\n"))
+
+  (let ((left (get-checksum p-left))
+        (right (get-checksum p-right)))
+    (when (not (eq? left right))
+        (error 'verify "~s != ~s" left right))))
+
+(module+ main
+  (verify)
+  (define text (read-c (command-line #:args (filename) filename)))
+  (define p (printer 0 0 (getenv "QUIET")))
+
+  (notify (format "Racket\t~s" (getpid)))
+  (time (run (parse text) (tape (vector 0) 0) p))
+  (notify "stop")
+
+  (when (printer-quiet p) (printf "Output checksum: ~s\n" (get-checksum p))))


### PR DESCRIPTION
This pull request adds a Racket variant for the `bf` benchmark that parses bf syntax directly into Racket syntax, omitting the explicit interpretation loop and dynamic dispatch on bf's instructions.

This is not cheating, because it's a very reasonable and common approach to building interpreters in Racket, and there's no clever tricks such as collapsing instructions.