### PR TITLE
Rework F# bf in more idiomatic style:

### DIFF
--- a/brainfuck/fsharp/bf.fs
+++ b/brainfuck/fsharp/bf.fs
@@ -1,123 +1,186 @@
 open System
+module Tape =
+
+    [<Struct>]
+    type t = { data: int array; pos: int }
+
+    let create () = { data = [| 0 |]; pos = 0 }
+    let current t = t.data.[t.pos]
+    let inc t delta =
+        t.data.[t.pos] <- t.data.[t.pos] + delta
+        t
+
+    let move t m =
+        let newPos = t.pos + m
+        let arrayLen = Array.length t.data
+        if newPos >= arrayLen then
+            let newData = Array.append t.data (Array.create (2 * arrayLen) 0)
+            { data = newData; pos = newPos }
+        else
+            { t with pos = newPos }
+
+module Printer =
+    [<Struct>]
+    type sum =
+        { sum1: int
+          sum2: int }
+    
+    [<Struct>]
+    type t =
+        | Quiet of sum
+        | Stdout
+
+    let createQuiet () = Quiet { sum1 = 0; sum2 = 0 }
+    let createStdout () = Stdout
+
+    let print p n =
+        match p with
+        | Stdout ->
+            Console.Out.Write(char n)
+            Console.Out.Flush()
+            p
+        | Quiet p ->
+            let newSum1 = (p.sum1 + n) % 255
+            let newSum2 = (newSum1 + p.sum2) % 255
+            Quiet { sum1 = newSum1; sum2 = newSum2 }
+            
+    let checksum = function
+        | Stdout -> 0
+        | Quiet sm -> (sm.sum2 <<< 8) ||| sm.sum1
+
+    let isQuiet = function
+        | Quiet _ -> true
+        | _ -> false
+
+module Interpreter =
+    
+    [<Struct>]
+    type Op =
+        | Inc of delta: int
+        | Move of steps: int
+        | Print
+        | Input
+        | Loop of opcodes: List<Op>
+        | Comment 
+
+    let parse (s: string) =
+        let rec _parse res s =
+            match s with
+            | [] -> List.rev res, List.empty
+            | ']' :: tail -> List.rev res, tail
+            | '[' :: tail ->
+                let (codes, newTail) = _parse [] tail
+                _parse (Loop codes :: res) newTail
+            | ch :: tail ->
+                let code =
+                    match ch with
+                    | '+' -> Inc 1
+                    | '-' -> Inc -1
+                    | '>' -> Move 1
+                    | '<' -> Move -1
+                    | '.' -> Print
+                    | _ -> Comment // | ',' -> Input
+                _parse (code :: res) tail
+        Seq.toList s
+            |> _parse []
+            |> fst
+
+    let rec run tape printer program = 
+        let rec _run (tape, printer) = function
+            | [] -> (tape, printer)
+            | Inc delta :: restProgram ->
+                _run ((Tape.inc tape delta), printer) restProgram
+            | Move delta :: rest ->
+                _run ((Tape.move tape delta), printer) rest
+            | Print :: rest ->
+                let newP = Tape.current tape |> Printer.print printer
+                _run (tape, newP) rest
+            | Loop loopCode :: rest ->
+                let rec loop (tape, printer)  =
+                    if Tape.current tape = 0 then
+                        _run (tape, printer) rest
+                    else
+                        _run (tape, printer) loopCode |> loop 
+                loop (tape, printer)
+            | _ :: rest -> _run (tape, printer) rest // Comment and Input are not implemented, so just skip them
+        _run (tape, printer) program
+    
+    let runWithNewTape printer program =
+        run (Tape.create ()) printer program
+        |> snd
+
+module Util =
+    let notify (msg: string) =
+        try
+            use s = new System.Net.Sockets.TcpClient("localhost", 9001)
+            msg
+                |> System.Text.Encoding.UTF8.GetBytes
+                |> s.Client.Send
+                |> ignore
+        with _ -> ()
+
+    let verify () =
+        let source = "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>\
+            ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++."
+
+        let left =
+            Interpreter.parse source
+            |> Interpreter.runWithNewTape (Printer.createQuiet ())
+            |> Printer.checksum
+
+        let right =
+            "Hello World!\n"
+            |> Seq.map int
+            |> Seq.fold Printer.print (Printer.createQuiet())
+            |> Printer.checksum
+
+        if left <> right
+        then sprintf "%d != %d" left right |> Result.Error
+        else Result.Ok None
+
+    let isQuiet =
+        Environment.GetEnvironmentVariable("QUIET")
+        <> null
+
+    let runtime =
+        if isNull (Type.GetType("Mono.Runtime")) then ".NET Core" else "Mono"
+
 open System.Diagnostics
 open System.IO
-
-type Op = Inc of int | Move of int | Print | Loop of Op list
-type Tape =
-    { data : int array;
-      pos : int;
-  }
-type Printer =
-    { sum1 : int;
-      sum2: int;
-      quiet: bool;
-  }
-
-let print p n =
-    if p.quiet then
-        let newSum1 = (p.sum1 + n) % 255
-        let newSum2 = (newSum1 + p.sum2) % 255
-        { sum1 = newSum1; sum2 = newSum2; quiet = true }
-    else
-        printf "%c" (char n)
-        Console.Out.Flush()
-        p
-
-let getChecksum p = (p.sum2 <<< 8) ||| p.sum1
-
-let current t =
-    t.data.[t.pos]
-
-let inc delta t =
-    t.data.[t.pos] <- t.data.[t.pos] + delta
-
-let move m t =
-    let newPos = t.pos + m
-    let len = Array.length t.data
-    let newData =
-        if newPos < len then t.data
-        else Array.append t.data (Array.create (newPos - len + 1) 0)
-    { data = newData; pos = newPos }
-
-let rec parse (s, acc) =
-    if s = "" then ("", List.rev acc)
-    else
-        let c = s.[0]
-        let rest = s.[1..((String.length s) - 1)]
-        match c with
-        | '+' -> parse (rest, Inc 1 :: acc)
-        | '-' -> parse (rest, Inc -1 :: acc)
-        | '>' -> parse (rest, Move 1 :: acc)
-        | '<' -> parse (rest, Move -1 :: acc)
-        | '.' -> parse (rest, Print :: acc)
-        | '[' ->
-            let (newS, loopCode) = parse (rest, [])
-            parse (newS, Loop loopCode :: acc)
-        | ']' -> (rest, List.rev acc)
-        | _ -> parse (rest, acc)
-
-let rec run program t p =
-    match program with
-    | [] -> (t, p)
-    | Inc d :: ops ->
-        inc d t
-        run ops t p
-    | Move m :: ops -> run ops (move m t) p
-    | Print :: ops ->
-        let newP = t |> current |> print p
-        run ops t newP
-    | Loop loopCode :: ops ->
-        let rec loop (t, p) =
-            if current t = 0 then run ops t p
-            else run loopCode t p |> loop
-        in loop (t, p)
-
-let notify (msg: string) =
-    try
-        use s = new System.Net.Sockets.TcpClient("localhost", 9001)
-        let data = System.Text.Encoding.UTF8.GetBytes(msg)
-        ignore(s.Client.Send(data))
-    with _ -> ()
-
-let verify =
-    let source = "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>\
-        ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++."
-    let (_, ops) = parse(source, [])
-    let p = { sum1 = 0; sum2 = 0; quiet = true }
-    let (_, pLeft) = run ops { data = [| 0 |]; pos = 0 } p
-    let left = getChecksum pLeft
-
-    let seq = [for c in "Hello World!\n" -> (int c)]
-    let pRight = List.fold print p seq
-    let right = getChecksum pRight
-    if left <> right then
-        Printf.eprintf "%d != %d\n" left right;
-        exit 1
-
+    
 [<EntryPoint>]
 let main argv =
-    verify
+    match Util.verify () with
+    | Error error ->
+        printfn "%A" error
+        exit 1
+    | Ok _ -> ()
+
     match argv with
     | [| filename |] ->
-        let source =
-            File.ReadAllLines filename
-            |> String.concat "\n"
-        let quiet = Environment.GetEnvironmentVariable("QUIET") <> null
-        let p = { sum1 = 0; sum2 = 0; quiet = quiet}
+        let source = File.ReadAllText filename
+        let printer = if Util.isQuiet then Printer.createQuiet () else Printer.createStdout ()
 
-        let runtime = if isNull(Type.GetType("Mono.Runtime")) then ".NET Core" else "Mono"
-        notify(String.Format("F#/{0}\t{1}", runtime, Process.GetCurrentProcess().Id))
+        (Util.runtime, Process.GetCurrentProcess().Id)
+        ||> sprintf "F#/%s\t%d"
+        |> Util.notify
+
         let stopWatch = Stopwatch.StartNew()
 
-        let (_, ops) = parse(source, [])
-        let (_, pNew) = run ops { data = [| 0 |]; pos = 0 } p
+        let pNew =
+            Interpreter.parse source
+            |> Interpreter.runWithNewTape printer
+
         stopWatch.Stop()
+
         let elapsed = stopWatch.Elapsed.TotalSeconds
 
-        notify("stop")
+        Util.notify "stop"
+        printfn "time: %Os" elapsed
 
-        Console.Error.WriteLine("time: {0}s", elapsed)
-        if pNew.quiet then
-            printf "Output checksum: %d\n" (getChecksum pNew)
+        if Printer.isQuiet pNew then
+            Printer.checksum pNew |> printf "Output checksum: %d\n"
         0
-    | _ -> 1
+    | _ ->
+        printfn "usage: bf.fs <brainfuck.b>"
+        1


### PR DESCRIPTION
Restructure code in more idiomatic way.
[<Struct>] is used in order to force stack allocation, otherwise there will be unnecessary GC overuse
It also possible to make Tape and Printer structs mutable, and gain additional ~20 sec boost.

On my laptop for **mandel.b**  time got reduced from
`time: 168.3062801s`
to
`time: 53.4273503s`

With mutable types time ~ 35s (20s boost)
