### PR TITLE
Add F# json

### DIFF
--- a/common/commands.mk
+++ b/common/commands.mk
@@ -74,7 +74,7 @@ SCHEME_RUN =		$(XTIME) scheme --optimize-level 3 --program $^
 JULIA_RUN =		$(XTIME) julia --optimize=3 --check-bounds=no $^
 
 GIT_CLONE = git clone --depth 1 -q
-DOTNET_CLEAN = -dotnet clean --nologo -v q
+DOTNET_CLEAN = -dotnet clean --nologo -v q -c Release
 NUGET_INSTALL = nuget install -ExcludeVersion -Verbosity quiet
 
 py_fmt := target/.py_fmt

--- a/json/Makefile
+++ b/json/Makefile
@@ -39,7 +39,8 @@ executables := \
 	target/json_v_clang \
 	target/json_vala_gcc \
 	target/json_vala_clang \
-	target/json_dawjsonlink_cpp
+	target/json_dawjsonlink_cpp \
+	json-fsharp/target/Release/net5.0/json-fsharp
 
 artifacts := $(executables) \
 	target/test.exe \
@@ -242,6 +243,9 @@ target/json_dawjsonlink_cpp: test_dawjsonlink.cpp | $(daw_json_link_all) $(boost
 		-I$(daw_json_link_all)/header_libraries/include \
 		-I$(daw_json_link_all)/utf_range/include -I$(boost)
 
+json-fsharp/target/Release/net5.0/json-fsharp: json-fsharp/json-fsharp.fsproj
+	$(DOTNET_BUILD)
+
 # Run
 
 .PHONY: run
@@ -339,6 +343,7 @@ clean:
 	$(MAKE) -C json-java clean
 	$(MAKE) -C json-hs clean
 	$(DOTNET_CLEAN) json-core/json-core.csproj
+	$(DOTNET_CLEAN) json-fsharp/json-fsharp.fsproj
 	cargo clean --manifest-path $(json-rs-toml)
 	-rm -rf target
 

--- a/json/json-fsharp/Program.fs
+++ b/json/json-fsharp/Program.fs
@@ -32,8 +32,9 @@ module Util =
         with _ -> ()
 
     let runtimeId =
-        let runtime = if isNull (Type.GetType "Mono.Runtime") then ".NET Core" else "Mono"
-        sprintf "F#/%s\t%d" runtime (Process.GetCurrentProcess().Id)
+        sprintf "F#/%s\t%d" 
+            "F#/.NET Core (System.Text.Json)"
+            (Process.GetCurrentProcess().Id)
 
     let validate () =
         let expected = { x = 2.0; y = 0.5; z = 0.25 }

--- a/json/json-fsharp/Program.fs
+++ b/json/json-fsharp/Program.fs
@@ -1,0 +1,69 @@
+module JsonTest
+
+open System.Text.Json
+open System.Text.Json.Serialization
+
+type Coordinate = { x: double; y: double; z: double }
+type Root = { coordinates: List<Coordinate> }
+
+let calc (text: string) =
+    let jso = JsonSerializerOptions()
+    jso.Converters.Add (JsonFSharpConverter())
+
+    let root: Root = JsonSerializer.Deserialize (text, jso)
+    let count = List.length root.coordinates |> double
+
+    let folder (x, y, z) c = (c.x + x, c.y + y, c.z + z)
+
+    let (x, y, z) = List.fold folder (0.0, 0.0, 0.0) root.coordinates
+
+    { x = x / count; y = y / count; z = z / count }
+
+module Util =
+    open System.Diagnostics
+    open System
+    let notify (msg: string) =
+        try
+            use s = new Net.Sockets.TcpClient("localhost", 9001)
+            msg
+                |> System.Text.Encoding.UTF8.GetBytes
+                |> s.Client.Send
+                |> ignore
+        with _ -> ()
+
+    let runtimeId =
+        let runtime = if isNull (Type.GetType "Mono.Runtime") then ".NET Core" else "Mono"
+        sprintf "F#/%s\t%d" runtime (Process.GetCurrentProcess().Id)
+
+    let validate () =
+        let expected = { x = 2.0; y = 0.5; z = 0.25 }
+        [
+            """{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}""";
+            """{"coordinates":[{"y":0.5,"z":0.25,"x":2.0}]}"""]
+        |> List.choose (fun s ->
+            let actual = calc s
+            if actual = expected then
+                None
+            else 
+                Some <| sprintf "%A != %A" actual expected)
+        |> function
+        | [] -> None
+        | errors -> Some <| String.concat "," errors
+
+
+open System.IO
+[<EntryPoint>]
+let main argv =
+    match Util.validate () with
+    | Some error ->
+        eprintf "%O" error
+        exit 1
+    | _ -> ()
+
+    let text = File.ReadAllText "/tmp/1.json"
+    Util.notify Util.runtimeId
+    let result = calc text
+    Util.notify "stop"
+
+    printfn "Coordinate {X: %O, Y: %O, Z: %O}" result.x result.y result.z
+    0

--- a/json/json-fsharp/json-fsharp.fsproj
+++ b/json/json-fsharp/json-fsharp.fsproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.SystemTextJson" Version="0.16.6" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`dotnet build` creates executable wrapper for .dll assembly, so I added target to `executables` (without run[..] target)