### PR TITLE
Use equivalent `gcc` flags with `rustc`

### DIFF
--- a/base64/base64.rs/Cargo.toml
+++ b/base64/base64.rs/Cargo.toml
@@ -5,6 +5,3 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13.0"
-
-[profile.release]
-lto = true

--- a/common/commands.mk
+++ b/common/commands.mk
@@ -2,6 +2,7 @@ GCC_FLAGS := -O3 -march=native -Wall -flto -Wa,-mbranches-within-32B-boundaries
 CLANG_FLAGS := -O3 -mbranches-within-32B-boundaries
 LIBNOTIFY_FLAGS := -I../common/libnotify ../common/libnotify/target/libnotify.a
 NIM_FLAGS := -d:danger --verbosity:0 --opt:speed --hints:off
+RUSTC_FLAGS := -C opt-level=3 -C target-cpu=native -C lto -C codegen-units=1 -C llvm-args="--x86-branches-within-32B-boundaries"
 VALAC_FLAGS := --disable-assert -X -O3 --pkg gio-2.0 --pkg posix
 V_FLAGS := -prod
 
@@ -24,7 +25,7 @@ MCS_BUILD =		mcs -debug- -optimize+ -out:$@ $^
 MLTON_BUILD =		mlton -output $@ $^
 NIM_CLANG_BUILD =	nim c -o:$@ --cc:clang $(NIM_FLAGS) $^
 NIM_GCC_BUILD =	nim c -o:$@ --cc:gcc $(NIM_FLAGS) $^
-RUSTC_BUILD =		rustc -C opt-level=3 -C lto -o $@ $^
+RUSTC_BUILD =		rustc $(RUSTC_FLAGS) -o $@ $^
 SCALAC_BUILD =		scalac -d $@ $^
 VALAC_CLANG_BUILD =	valac $^ --cc=clang -D CLANG_TEST $(VALAC_FLAGS) -o $@
 VALAC_GCC_BUILD =	valac $^ --cc=gcc -D GCC_TEST $(VALAC_FLAGS) -o $@

--- a/common/commands.mk
+++ b/common/commands.mk
@@ -2,7 +2,7 @@ GCC_FLAGS := -O3 -march=native -Wall -flto -Wa,-mbranches-within-32B-boundaries
 CLANG_FLAGS := -O3 -mbranches-within-32B-boundaries
 LIBNOTIFY_FLAGS := -I../common/libnotify ../common/libnotify/target/libnotify.a
 NIM_FLAGS := -d:danger --verbosity:0 --opt:speed --hints:off
-RUSTC_FLAGS := -C opt-level=3 -C target-cpu=native -C lto -C codegen-units=1 -C llvm-args="--x86-branches-within-32B-boundaries"
+RUSTC_FLAGS := -C opt-level=3 -C target-cpu=native -C lto -C codegen-units=1 -C llvm-args=--x86-branches-within-32B-boundaries
 VALAC_FLAGS := --disable-assert -X -O3 --pkg gio-2.0 --pkg posix
 V_FLAGS := -prod
 
@@ -39,7 +39,7 @@ endef
 define CARGO_BUILD =
 cargo fmt --manifest-path $<
 cargo clippy -q --manifest-path $<
-cargo build -q --manifest-path $< --release
+RUSTFLAGS="$(RUSTC_FLAGS)" cargo build -q --manifest-path $< --release
 endef
 
 ECHO_RUN = @tput bold; echo "$(MAKE) $@"; tput sgr0

--- a/json/json.rs/Cargo.toml
+++ b/json/json.rs/Cargo.toml
@@ -9,9 +9,6 @@ serde_derive = "1.0.125"
 serde_json = "1.0.64"
 jq-rs = "0.4.1"
 
-[profile.release]
-lto = true
-
 [[bin]]
 name = "json-value-rs"
 path = "src/json_value.rs"


### PR DESCRIPTION
The `codegen-units` flag controls the parallelism of the LTO (1=slow compile, fast binary; 256=fast compile, slow binary).