### PR TITLE
Update the Rust's brainfuck implementation

### DIFF
--- a/brainfuck/bf.rs
+++ b/brainfuck/bf.rs
@@ -1,46 +1,74 @@
-use std::io;
-use std::fs;
 use std::env;
+use std::fs;
+use std::io::{self, prelude::*};
+use std::process;
 
 enum Op {
     Inc(i32),
     Move(isize),
     Loop(Box<[Op]>),
-    Print
+    Print,
 }
 use Op::*;
 
 struct Tape {
     pos: usize,
-    tape: Vec<i32>
+    tape: Vec<i32>,
 }
 
 impl Tape {
-    fn new() -> Tape { Tape { pos: 0, tape: vec![0] } }
-    fn get(&self) -> i32 { self.tape[self.pos] }
-    fn inc(&mut self, x: i32) { self.tape[self.pos] += x; }
+    fn new() -> Self {
+        Default::default()
+    }
+
+    fn get(&self) -> i32 {
+        unsafe { *self.tape.get_unchecked(self.pos) } // Always safe
+    }
+
+    fn inc(&mut self, x: i32) {
+        unsafe { *self.tape.get_unchecked_mut(self.pos) += x; } // Always safe
+    }
+
     fn mov(&mut self, x: isize) {
         self.pos = (self.pos as isize + x) as usize;
-        while self.pos >= self.tape.len() { self.tape.push(0); }
+        if self.pos >= self.tape.len() {
+            self.tape.resize(self.pos << 1, 0);
+        }
     }
 }
 
+impl Default for Tape {
+    fn default() -> Self {
+        Self {
+            pos: 0,
+            tape: vec![0],
+        }
+    }
+}
+
+#[derive(Default)]
 struct Printer {
     sum1: i32,
     sum2: i32,
-    quiet: bool
+    quiet: bool,
 }
 
 impl Printer {
-    fn new(quiet: bool) -> Printer { Printer { sum1: 0, sum2: 0, quiet: quiet} }
+    fn new(quiet: bool) -> Self {
+        Self {
+            quiet,
+            ..Default::default()
+        }
+    }
 
     fn print(&mut self, n: i32) {
         if self.quiet {
             self.sum1 = (self.sum1 + n) % 255;
             self.sum2 = (self.sum2 + self.sum1) % 255;
         } else {
-            print!("{}", n as u8 as char);
-            io::Write::flush(&mut io::stdout()).unwrap();
+            let mut stdout = io::stdout();
+            stdout.lock().write_all(&[n as u8]).ok();
+            stdout.flush().ok();
         }
     }
 
@@ -49,14 +77,16 @@ impl Printer {
     }
 }
 
-fn _run(program: &[Op], tape: &mut Tape, p: &mut Printer) {
+fn run(program: &[Op], tape: &mut Tape, p: &mut Printer) {
     for op in program {
         match *op {
             Inc(x) => tape.inc(x),
             Move(x) => tape.mov(x),
-            Loop(ref program) => while tape.get() > 0 {
-                _run(program, tape, p);
-            },
+            Loop(ref program) => {
+                while tape.get() > 0 {
+                    run(program, tape, p);
+                }
+            }
             Print => {
                 p.print(tape.get());
             }
@@ -64,10 +94,10 @@ fn _run(program: &[Op], tape: &mut Tape, p: &mut Printer) {
     }
 }
 
-fn parse<I: Iterator<Item=char>>(it: &mut I) -> Box<[Op]> {
-    let mut buf = Vec::new();
+fn parse<I: Iterator<Item = char>>(it: &mut I) -> Box<[Op]> {
+    let mut buf = vec![];
     while let Some(c) = it.next() {
-        buf.push( match c {
+        buf.push(match c {
             '+' => Inc(1),
             '-' => Inc(-1),
             '>' => Move(1),
@@ -76,34 +106,39 @@ fn parse<I: Iterator<Item=char>>(it: &mut I) -> Box<[Op]> {
             '[' => Loop(parse(it)),
             ']' => break,
             _ => continue,
-        } );
+        });
     }
     buf.into_boxed_slice()
 }
 
 struct Program {
-    ops: Box<[Op]>
+    ops: Box<[Op]>,
 }
 
 impl Program {
-    fn new(code: String) -> Program { Program { ops: parse(&mut code.chars()) } }
+    fn new(code: String) -> Self {
+        Self {
+            ops: parse(&mut code.chars()),
+        }
+    }
+
     fn run(&self, p: &mut Printer) {
         let mut tape = Tape::new();
-        _run(&self.ops, &mut tape, p);
+        run(&self.ops, &mut tape, p);
     }
 }
 
 fn notify(msg: &str) {
-    use std::io::Write;
-
     if let Ok(mut stream) = std::net::TcpStream::connect("localhost:9001") {
-        stream.write_all(msg.as_bytes()).unwrap();
+        stream.write_all(msg.as_bytes()).ok();
     }
 }
 
 fn verify() {
-    let s = String::from("++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>
-        ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.");
+    let s = String::from(
+        "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>
+        ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.",
+    );
     let mut p_left = Printer::new(true);
     Program::new(s).run(&mut p_left);
     let left = p_left.get_checksum();
@@ -114,8 +149,8 @@ fn verify() {
     }
     let right = p_right.get_checksum();
     if left != right {
-        eprintln!("{:?} != {:?}", left, right);
-        std::process::exit(-1);
+        eprintln!("{} != {}", left, right);
+        process::exit(-1);
     }
 }
 
@@ -124,9 +159,9 @@ fn main() {
 
     let arg1 = env::args().nth(1).unwrap();
     let s = fs::read_to_string(arg1).unwrap();
-    let mut p = Printer::new(std::env::var("QUIET").is_ok());
+    let mut p = Printer::new(env::var("QUIET").is_ok());
 
-    notify(&format!("Rust\t{}", std::process::id()));
+    notify(&format!("Rust\t{}", process::id()));
     Program::new(s).run(&mut p);
     notify("stop");
 

--- a/brainfuck/bf.rs
+++ b/brainfuck/bf.rs
@@ -116,7 +116,7 @@ struct Program {
 }
 
 impl Program {
-    fn new(code: String) -> Self {
+    fn new(code: &str) -> Self {
         Self {
             ops: parse(&mut code.chars()),
         }
@@ -135,10 +135,8 @@ fn notify(msg: &str) {
 }
 
 fn verify() {
-    let s = String::from(
-        "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>
-        ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.",
-    );
+    let s = "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>
+             ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.";
     let mut p_left = Printer::new(true);
     Program::new(s).run(&mut p_left);
     let left = p_left.get_checksum();
@@ -162,10 +160,11 @@ fn main() {
     let mut p = Printer::new(env::var("QUIET").is_ok());
 
     notify(&format!("Rust\t{}", process::id()));
-    Program::new(s).run(&mut p);
+    Program::new(&s).run(&mut p);
     notify("stop");
 
     if p.quiet {
         println!("Output checksum: {}", p.get_checksum());
     }
 }
+


### PR DESCRIPTION
More idiomatic code, and formatting with `rustfmt`. The most important change was in the `Tape` impl:

* `mov()` reallocs only once per call;
* `get()` and `inc()` uses unchecked indexing because the check is already done in `mov()`