### PR TITLE
Use more iterators in `matmul` (Rust)

### DIFF
--- a/matmul/matmul.rs
+++ b/matmul/matmul.rs
@@ -1,5 +1,3 @@
-// rustc -C opt-level=3 -C lto
-
 fn new_mat(x: usize, y: usize) -> Vec<Vec<f64>> {
     vec![vec![0f64; y]; x]
 }
@@ -8,32 +6,31 @@ fn mat_gen(n: usize, seed: f64) -> Vec<Vec<f64>> {
     let mut m = new_mat(n, n);
     let tmp = seed / (n as f64) / (n as f64);
 
-    for i in 0 .. n {
-        for j in 0 .. n {
-            m[i][j] = tmp * (i as f64 - j as f64) * (i as f64 + j as f64);
+    for (i, row) in m.iter_mut().enumerate() {
+        for (j, x) in row.iter_mut().enumerate() {
+            *x = tmp * (i as f64 - j as f64) * (i as f64 + j as f64);
         }
     }
     m
 }
 
-#[inline(never)]
 fn mat_mul(a: &[Vec<f64>], b: &[Vec<f64>]) -> Vec<Vec<f64>> {
     let m = a.len();
     let n = a[0].len();
     let p = b[0].len();
 
     let mut b2 = new_mat(n, p);
-    for i in 0 .. n {
-        for j in 0 .. p {
-            b2[j][i] = b[i][j];
+    for (i, row) in b.into_iter().enumerate() {
+        for (j, x) in row.into_iter().enumerate() {
+            b2[j][i] = *x;
         }
     }
 
     let mut c = new_mat(m, p);
 
-    for (i, ci) in c.iter_mut().enumerate() {
+    for (ci, a_row) in c.iter_mut().zip(a.into_iter()) {
         for (cij, b2j) in ci.iter_mut().zip(&b2) {
-            *cij = a[i].iter().zip(b2j).map(|(&x, y)| x * y).sum();
+            *cij = a_row.iter().zip(b2j).fold(0f64, |acc, (&x, y)| acc + x * y);
         }
     }
 
@@ -44,7 +41,7 @@ fn notify(msg: &str) {
     use std::io::Write;
 
     if let Ok(mut stream) = std::net::TcpStream::connect("localhost:9001") {
-        stream.write_all(msg.as_bytes()).unwrap();
+        stream.write_all(msg.as_bytes()).ok();
     }
 }
 
@@ -58,10 +55,10 @@ fn calc(n: usize) -> f64 {
 
 fn main() {
     let n = std::env::args()
-            .nth(1)
-            .unwrap_or("100".into())
-            .parse::<usize>()
-            .unwrap();
+        .nth(1)
+        .unwrap_or("100".into())
+        .parse::<usize>()
+        .unwrap();
 
     let left = calc(101);
     let right = -18.67;


### PR DESCRIPTION
More idiomatic, and a little improvement in execution time.