### PR TITLE
Allow test.zig to run on any POSIX system

### DIFF
--- a/brainfuck/bf.zig
+++ b/brainfuck/bf.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const unistd = @cImport(@cInclude("unistd.h"));
 
 const OpType = enum {
     INC,
@@ -183,7 +184,7 @@ pub fn main() !void {
     };
 
     const text = try readFile(alloc, name);
-    const pid = std.os.linux.getpid();
+    const pid = unistd.getpid();
     const pid_str = try std.fmt.allocPrint(alloc, "Zig\t{d}", .{pid});
 
     notify(pid_str);

--- a/json/test.zig
+++ b/json/test.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const unistd = @cImport(@cInclude("unistd.h"));
 
 const Coordinate = struct {
     x: f64,
@@ -65,7 +66,7 @@ pub fn main() !void {
     }
 
     const text = try readFile(alloc, "/tmp/1.json");
-    const pid = std.os.linux.getpid();
+    const pid = unistd.getpid();
     const pid_str = try std.fmt.allocPrint(alloc, "Zig\t{d}", .{pid});
 
     notify(pid_str);

--- a/matmul/matmul.zig
+++ b/matmul/matmul.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const unistd = @cImport(@cInclude("unistd.h"));
 
 fn matInit(alloc: *std.mem.Allocator, x: usize, y: usize) [][]f64 {
     var mat: [][]f64 = alloc.alloc([]f64, x) catch unreachable;
@@ -86,7 +87,7 @@ pub fn main() !void {
         std.debug.panic("{d} != {d}\n", .{left, right});
     }
 
-    const pid = std.os.linux.getpid();
+    const pid = unistd.getpid();
     const pid_str = try std.fmt.allocPrint(alloc, "Zig\t{d}", .{pid});
 
     notify(pid_str);

--- a/primes/primes.zig
+++ b/primes/primes.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const unistd = @cImport(@cInclude("unistd.h"));
 
 const UPPER_BOUND: i32 = 5_000_000;
 const PREFIX: i32 = 32_338;
@@ -181,7 +182,7 @@ pub fn main() !void {
 
     try verify(alloc);
 
-    const pid = std.os.linux.getpid();
+    const pid = unistd.getpid();
     const pid_str = try std.fmt.allocPrint(alloc, "Zig\t{d}", .{pid});
 
     notify(pid_str);


### PR DESCRIPTION
std.os.linux only works on linux.  By importing unistd.h and calling getpid( ) from it, it should work on any POSIX system.  Tested on MacOS 11.5.2 and Ubuntu 20.04