### PR TITLE
Fix undefined behavior in Zig tests

### DIFF
--- a/brainfuck/bf.zig
+++ b/brainfuck/bf.zig
@@ -132,9 +132,10 @@ const Program = struct {
 
 fn notify(msg: []const u8) void {
     const addr = std.net.Address.parseIp("127.0.0.1", 9001) catch unreachable;
-    var stream = std.net.tcpConnectToAddress(addr) catch unreachable;
-    _ = stream.write(msg) catch unreachable;
-    stream.close();
+    if (std.net.tcpConnectToAddress(addr)) |stream| {
+        defer stream.close();
+        _ = stream.write(msg) catch unreachable;
+    } else |_| {}
 }
 
 fn readFile(alloc: *std.mem.Allocator, filename: []const u8) ![]const u8 {

--- a/json/test.zig
+++ b/json/test.zig
@@ -17,9 +17,10 @@ const TestStruct = struct {
 
 fn notify(msg: []const u8) void {
     const addr = std.net.Address.parseIp("127.0.0.1", 9001) catch unreachable;
-    var stream = std.net.tcpConnectToAddress(addr) catch unreachable;
-    _ = stream.write(msg) catch unreachable;
-    stream.close();
+    if (std.net.tcpConnectToAddress(addr)) |stream| {
+        defer stream.close();
+        _ = stream.write(msg) catch unreachable;
+    } else |_| {}
 }
 
 fn readFile(alloc: *std.mem.Allocator, filename: []const u8) ![]const u8 {

--- a/matmul/matmul.zig
+++ b/matmul/matmul.zig
@@ -56,9 +56,10 @@ fn matMul(alloc: *std.mem.Allocator, a: [][]f64, b: [][]f64) [][]f64 {
 
 fn notify(msg: []const u8) void {
     const addr = std.net.Address.parseIp("127.0.0.1", 9001) catch unreachable;
-    var stream = std.net.tcpConnectToAddress(addr) catch unreachable;
-    _ = stream.write(msg) catch unreachable;
-    stream.close();
+    if (std.net.tcpConnectToAddress(addr)) |stream| {
+        defer stream.close();
+        _ = stream.write(msg) catch unreachable;
+    } else |_| {}
 }
 
 fn calc(alloc: *std.mem.Allocator, n: usize) f64 {

--- a/primes/primes.zig
+++ b/primes/primes.zig
@@ -158,9 +158,10 @@ fn find(alloc: *std.mem.Allocator, upper_bound: i32, prefix: i32) std.ArrayList(
 
 fn notify(msg: []const u8) void {
     const addr = std.net.Address.parseIp("127.0.0.1", 9001) catch unreachable;
-    var stream = std.net.tcpConnectToAddress(addr) catch unreachable;
-    _ = stream.write(msg) catch unreachable;
-    stream.close();
+    if (std.net.tcpConnectToAddress(addr)) |stream| {
+        defer stream.close();
+        _ = stream.write(msg) catch unreachable;
+    } else |_| {}
 }
 
 fn verify(alloc: *std.mem.Allocator) !void {


### PR DESCRIPTION
With current build setting (ReleaseFast), the notify function will
ignore error when there's no server set up. However, it's relying on
undefined behavior to achieve that, whereas with different build
setting it would panic, which is not a desired behavior.

This change makes notify function safely ignore error when connecting
to the server, regardless of build settings, making sure that the test
will continue its execution.

Signed-off-by: Radek Szymanski <radszy@pm.me>