### PR TITLE
Rust: Fix Result::ok usage and disable unwinding

### DIFF
--- a/brainfuck/bf.rs
+++ b/brainfuck/bf.rs
@@ -83,8 +83,8 @@ impl<'a> Printer<'a> {
             self.sum1 = (self.sum1 + n) % 255;
             self.sum2 = (self.sum2 + self.sum1) % 255;
         } else {
-            self.output.write_all(&[n as u8]).ok();
-            self.output.flush().ok();
+            self.output.write_all(&[n as u8]).unwrap();
+            self.output.flush().unwrap();
         }
     }
 
@@ -148,7 +148,7 @@ impl Program {
 
 fn notify(msg: &str) {
     if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
-        stream.write_all(msg.as_bytes()).ok();
+        stream.write_all(msg.as_bytes()).unwrap();
     }
 }
 

--- a/common/commands.mk
+++ b/common/commands.mk
@@ -3,7 +3,7 @@ GCC_FLAGS := -Wall -O3 $(COMMON_FLAGS)
 CLANG_FLAGS := -Wall -O3 $(COMMON_FLAGS)
 LIBNOTIFY_FLAGS := -I../common/libnotify ../common/libnotify/target/libnotify.a
 NIM_FLAGS := -d:danger --verbosity:0 --opt:speed --hints:off --passC:"$(COMMON_FLAGS)" --passL:"-march=native -flto"
-RUSTC_FLAGS := -C opt-level=3 -C target-cpu=native -C llvm-args=--x86-branches-within-32B-boundaries
+RUSTC_FLAGS := -C opt-level=3 -C target-cpu=native -C llvm-args=--x86-branches-within-32B-boundaries -C panic=abort
 VALAC_FLAGS := --disable-assert -X -O3 -X -march=native -X -flto -X -Wa,-mbranches-within-32B-boundaries --pkg gio-2.0 --pkg posix
 V_FLAGS := -prod
 ZIG_FLAGS := -O ReleaseFast

--- a/matmul/matmul.rs
+++ b/matmul/matmul.rs
@@ -44,7 +44,7 @@ fn mat_mul(a: &[Vec<f64>], b: &[Vec<f64>]) -> Vec<Vec<f64>> {
 
 fn notify(msg: &str) {
     if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
-        stream.write_all(msg.as_bytes()).ok();
+        stream.write_all(msg.as_bytes()).unwrap();
     }
 }
 

--- a/primes/primes.rs
+++ b/primes/primes.rs
@@ -147,7 +147,7 @@ fn find(upper_bound: usize, prefix: i32) -> Vec<i32> {
 
 fn notify(msg: &str) {
     if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
-        stream.write_all(msg.as_bytes()).ok();
+        stream.write_all(msg.as_bytes()).unwrap();
     }
 }
 


### PR DESCRIPTION
This PR includes two changes.

## 1. Use `Result::unwrap` instead of `Result::ok`

This is fix for an obvious mistake. [`Result::ok`](https://doc.rust-lang.org/std/result/enum.Result.html#method.ok) is a method to convert `Result<T, E>` to `Option<T>`. Which does nothing other than the conversion. So `.ok()` method call at end of expression has no effect.

I guess [`Result::unwrap`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap) is the correct method to be called. It checks `Ok` value is contained, otherwise causes a panic.

## 2. Disable unwinding

Rust has some build configuration on panic occurs.

https://doc.rust-lang.org/book/ch09-01-unrecoverable-errors-with-panic.html

When `panic=unwind` (this is default configuration), a panic unwinds the program's stack for recovery. However, we don't need this behavior since we have nothing to do when panic occurs. For such use case, `panic=abort` is more suitable, which just aborts the program without unwinding stack.

Since unwinding stack require some small overhead on execution even if panics don't happen, `panic=abort` has small performance advantage against `panic=unwind`. Rough measurement on my local environment with hyperfine, it was about 4% faster.

```
$ hyperfine './before mandel.b' './after mandel.b'
Benchmark #1: ./before mandel.b
  Time (mean ± σ):     12.538 s ±  0.009 s    [User: 12.521 s, System: 0.011 s]
  Range (min … max):   12.518 s … 12.549 s    10 runs

Benchmark #2: ./after mandel.b
  Time (mean ± σ):     12.014 s ±  0.015 s    [User: 11.997 s, System: 0.012 s]
  Range (min … max):   12.002 s … 12.047 s    10 runs

Summary
  './after mandel.b' ran
    1.04 ± 0.00 times faster than './before mandel.b'
```

Where `./before` was built with `panic=unwind` and `./after` was built with `panic=abort`.