### PR TITLE
gcc-11 was reporting line 31 as error

### DIFF
--- a/common/libnotify/libnotify.c
+++ b/common/libnotify/libnotify.c
@@ -7,7 +7,7 @@
 
 #include "libnotify.h"
 
-static const size_t MAX_LEN = 32;
+#define MAX_LEN 32;
 
 void notify(const char* msg) {
   int sock = socket(AF_INET, SOCK_STREAM, 0);


### PR DESCRIPTION
g++-11 is reporting `libnotify.c:31:13: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]` Simple fix