### PR TITLE
Fix for missing symbol errors

### DIFF
--- a/common/libnotify/Makefile
+++ b/common/libnotify/Makefile
@@ -16,7 +16,7 @@ target/libnotify.so: target/libnotify.o
 	$(CC) -shared $^ -o $@
 
 target/lua_libnotify.so: target/libnotify.o target/lua.o
-	$(CC) -shared $^ -o $@
+	$(CC) -shared -llua5.4 $^ -o $@
 
 target:
 	mkdir -p $@


### PR DESCRIPTION
was getting errors ```
Undefined symbols for architecture x86_64:
  "_luaL_checklstring", referenced from:
      _lua_notify in lua.o
      _lua_notify_with_pid in lua.o
  "_luaL_checkversion_", referenced from:
      _luaopen_lua_libnotify in lua.o
  "_luaL_setfuncs", referenced from:
      _luaopen_lua_libnotify in lua.o
  "_lua_createtable", referenced from:
      _luaopen_lua_libnotify in lua.o```
This fixed them.  Tested on macos and linux