### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Run the image:
 
     $ docker run -it --rm -v $(pwd):/src benchmarks <cmd>
 
-where <cmd> is:
+where `<cmd>` is:
 
  - `versions` (print installed language versions);
  - `shell` (start the shell);


### PR DESCRIPTION
Makes `<cmd>` visible in the README (instead of interpreting it as HTML).