### PR TITLE
Add Nim JSON benchmark using jsony

### DIFF
--- a/json/Makefile
+++ b/json/Makefile
@@ -23,6 +23,8 @@ executables := \
 	target/json_nim_clang \
 	target/packedjson_nim_gcc \
 	target/packedjson_nim_clang \
+	target/jsony_nim_gcc \
+	target/jsony_nim_clang \
 	target/json_go \
 	target/json_go_gccgo \
 	target/json_iter_go \
@@ -138,6 +140,16 @@ target/packedjson_nim_gcc: test_packedjson.nim | target packedjson
 	$(NIM_GCC_BUILD)
 
 target/packedjson_nim_clang: test_packedjson.nim | target packedjson
+	$(NIM_CLANG_BUILD)
+
+.PHONY: jsony
+jsony:
+	nimble -y install jsony
+
+target/jsony_nim_gcc: test_jsony.nim | target jsony
+	$(NIM_GCC_BUILD)
+
+target/jsony_nim_clang: test_jsony.nim | target jsony
 	$(NIM_CLANG_BUILD)
 
 target/json_go: test.go | $(gofmt)

--- a/json/test_jsony.nim
+++ b/json/test_jsony.nim
@@ -1,0 +1,54 @@
+import std/[net, strformat, posix]
+import jsony
+
+type
+  Coordinate = tuple
+    x, y, z: float
+
+  CoordinateObject = object
+    coordinates: seq[Coordinate]
+
+proc notify(msg: string) =
+  try:
+    let socket = newSocket()
+    defer: socket.close()
+    socket.connect("localhost", Port(9001))
+    socket.send(msg)
+  except:
+    discard
+
+proc calc(text: string): Coordinate =
+  let obj = text.fromJson(CoordinateObject)
+
+  let coordinates = obj.coordinates
+  let len = float(coordinates.len)
+  var x, y, z: float
+
+  for coord in coordinates:
+    x += coord.x
+    y += coord.y
+    z += coord.z
+
+  result = (x: x / len, y: y / len, z: z / len)
+
+when isMainModule:
+  let right = (x: 2.0, y: 0.5, z: 0.25)
+  for v in ["""{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}""",
+            """{"coordinates":[{"y":0.5,"x":2.0,"z":0.25}]}"""]:
+    let left = calc(v)
+    if left != right:
+      stderr.writeLine(&"{left} != {right}")
+      quit(1)
+
+  let text = "/tmp/1.json".readFile()
+
+  let compiler = when defined(gcc):
+    "Nim/gcc (jsony)"
+  else:
+    "Nim/clang (jsony)"
+
+  notify(&"{compiler}\t{getpid()}")
+  let results = calc(text)
+  notify("stop")
+
+  echo results


### PR DESCRIPTION
Add JSON benchmarks for Nim using the [jsony](https://github.com/treeform/jsony) library.
On my machine, this is ~2x faster than packedjson, using ~7x less memory.

This is based off of the other Nim JSON benchmarks with minor non-performance enhancing changes. These might be beneficial to change in the other tests as well.