### PR TITLE
Modernize the Rust version of the BF

### DIFF
--- a/base64/base64.rs/Cargo.toml
+++ b/base64/base64.rs/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [profile.release]
 lto = true
 codegen-units = 1
+panic = "abort"
 
 [dependencies]
 base64 = "0.13.0"

--- a/brainfuck/bf.rs
+++ b/brainfuck/bf.rs
@@ -93,12 +93,12 @@ fn run(program: &[Op], tape: &mut Tape, p: &mut Printer) {
             Op::Inc => tape.inc(),
             Op::Prev => tape.prev(),
             Op::Next => tape.next(),
+            Op::Print => p.print(tape.get()),
             Op::Loop(program) => {
                 while tape.get() > 0 {
                     run(program, tape, p);
                 }
             }
-            Op::Print => p.print(tape.get()),
         }
     }
 }
@@ -149,22 +149,22 @@ fn verify() {
 
     let left = {
         let output = io::stdout();
-        let mut p_left = Printer::new(&output, true);
-        Program::new(S).run(&mut p_left);
-        p_left.get_checksum()
+        let mut p = Printer::new(&output, true);
+        Program::new(S).run(&mut p);
+        p.get_checksum()
     };
 
     let right = {
         let output = io::stdout();
-        let mut p_right = Printer::new(&output, true);
+        let mut p = Printer::new(&output, true);
         for &c in b"Hello World!\n" {
-            p_right.print(c as i32);
+            p.print(c as i32);
         }
-        p_right.get_checksum()
+        p.get_checksum()
     };
 
     if left != right {
-        eprintln!("{} != {}", left, right);
+        eprintln!("{left} != {right}");
         process::exit(-1);
     }
 }
@@ -175,7 +175,7 @@ fn main() {
     let output = io::stdout();
     let mut p = Printer::new(&output, env::var("QUIET").is_ok());
 
-    notify(&format!("Rust\t{}", process::id()));
+    notify(&format!("Rust\t{pid}", pid = process::id()));
     Program::new(&s).run(&mut p);
     notify("stop");
 

--- a/common/commands.mk
+++ b/common/commands.mk
@@ -4,7 +4,7 @@ GCC_FLAGS := $(COMMON_FLAGS)
 CLANG_FLAGS := $(COMMON_FLAGS)
 LIBNOTIFY_FLAGS := -I../common/libnotify ../common/libnotify/target/libnotify.a
 NIM_FLAGS := -d:danger --verbosity:0 --opt:speed --hints:off --passC:"$(COMMON_FLAGS)" --passL:"-march=native -flto"
-RUSTC_FLAGS := -C opt-level=3 -C target-cpu=native -C llvm-args=--x86-branches-within-32B-boundaries -C panic=abort
+RUSTC_FLAGS := -C target-cpu=native -C llvm-args=--x86-branches-within-32B-boundaries
 VALAC_FLAGS := --disable-assert -X -O3 -X -march=native -X -flto -X -Wa,-mbranches-within-32B-boundaries --pkg gio-2.0 --pkg posix
 V_FLAGS := -prod
 ZIG_FLAGS := -O ReleaseFast
@@ -28,7 +28,7 @@ MCS_BUILD =		mcs -debug- -optimize+ -out:$@ $^
 MLTON_BUILD =		mlton -output $@ $^
 NIM_CLANG_BUILD =	nim c -o:$@ --cc:clang $(NIM_FLAGS) $^
 NIM_GCC_BUILD =	nim c -o:$@ --cc:gcc $(NIM_FLAGS) $^
-RUSTC_BUILD =		rustc $(RUSTC_FLAGS) -C lto -C codegen-units=1 -o $@ $^
+RUSTC_BUILD =		rustc $(RUSTC_FLAGS) -C opt-level=3 -C lto -C codegen-units=1 -C panic=abort -o $@ $^
 RUST_CLIPPY =		clippy-driver -o $@.clippy $^
 SWIFTC_BUILD =		swiftc -parse-as-library -Ounchecked -cross-module-optimization -o $@ $^
 SCALAC_BUILD =		scalac -release 17 -d $@ $^

--- a/json/json.rs/Cargo.toml
+++ b/json/json.rs/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [profile.release]
 lto = true
 codegen-units = 1
+panic = "abort"
 
 [dependencies]
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
* Use captured identifiers in format strings and shorter names in nested scopes
* Remove duplicate rustc flags (`--release` implies `-C opt-level=3`)