### PR TITLE
Simplified multiplication of the matrices

### DIFF
--- a/matmul/matmul.go
+++ b/matmul/matmul.go
@@ -29,25 +29,16 @@ func matmul(a [][]float64, b [][]float64) [][]float64 {
 	m := len(a)
 	n := len(a[0])
 	p := len(b[0])
-	x := make([][]float64, m)
-	c := make([][]float64, p)
-	for i := 0; i < p; i++ {
-		c[i] = make([]float64, n)
-		for j := 0; j < n; j++ {
-			c[i][j] = b[j][i]
-		}
-	}
-	for i, am := range a {
-		x[i] = make([]float64, p)
-		for j, cm := range c {
-			s := float64(0)
-			for k, m := range am {
-				s += m * cm[k]
+	c := make([][]float64, m)
+	for i := 0; i < m; i++ {
+		c[i] = make([]float64, p)
+		for j := 0; j < p; j++ {
+			for k := 0; k < n; k++ {
+				c[i][j] += a[i][k] * b[k][j]
 			}
-			x[i][j] = s
 		}
 	}
-	return x
+	return c
 }
 
 func notify(msg string) {


### PR DESCRIPTION
The version that I am modifying created a transpose `c` of matrix `b`, which is completely unnecessary. This meant wasted memory and wasted CPU cycles, amounting to a program slower than it should have been for such an elementary task (in particular, it was slower than almost half of the other benchmarked programs written in the other languages). The version that I am proposing is functionally identical, but uses less memory and is faster by dropping the needless intermediate allocations for the transpose.