### PR TITLE
Optimize the V version of the BF interpreter.

### DIFF
--- a/brainfuck/bf.v
+++ b/brainfuck/bf.v
@@ -42,10 +42,12 @@ fn new_tape() Tape {
 	return t
 }
 
+[direct_array_access]
 fn (t Tape) get() int {
 	return t.tape[t.pos]
 }
 
+[direct_array_access]
 fn (mut t Tape) inc(x int) {
 	t.tape[t.pos] += x
 }

--- a/brainfuck/bf.v
+++ b/brainfuck/bf.v
@@ -55,7 +55,7 @@ fn (mut t Tape) inc(x int) {
 fn (mut t Tape) move(x int) {
 	t.pos += x
 	for t.pos >= t.tape.len {
-		t.tape << 0
+		t.tape << [0]
 	}
 }
 


### PR DESCRIPTION
V does bounds checking by default on each array access. 

Using `[direct_array_access]` over a function/method, disables the checks inside its body.

The brainfuck implementation does call very frequently the methods .get() and .inc() , which boil down to array access operations.

With this change, the V implementation is within 5% of the C version, when it is compiled with `-prod` (and the C version is compiled with -O3) on my machine.