### PR TITLE
add nim primes

### DIFF
--- a/primes/Makefile
+++ b/primes/Makefile
@@ -8,8 +8,10 @@ executables := \
 	target/primes_cr \
 	target/primes_v_gcc \
 	target/primes_v_clang \
-	target/primes_zig
-
+	target/primes_zig \
+	target/bin_nim_clang \
+	target/bin_nim_gcc
+	
 artifacts := $(executables) \
 	target/primes_scala.jar \
 	target/Primes.class
@@ -61,6 +63,11 @@ target/primes_v_clang: primes.v | $(v_fmt)
 target/primes_zig: primes.zig | target
 	$(ZIG_BUILD)
 
+target/primes_nim_clang: primes.nim | target
+	$(NIM_CLANG_BUILD)
+
+target/primes_nim_gcc: primes.nim | target
+	$(NIM_GCC_BUILD)
 # Run
 
 .PHONY: run

--- a/primes/Makefile
+++ b/primes/Makefile
@@ -9,8 +9,8 @@ executables := \
 	target/primes_v_gcc \
 	target/primes_v_clang \
 	target/primes_zig \
-	target/bin_nim_clang \
-	target/bin_nim_gcc
+	target/primes_nim_clang \
+	target/primes_nim_gcc
 	
 artifacts := $(executables) \
 	target/primes_scala.jar \

--- a/primes/primes.nim
+++ b/primes/primes.nim
@@ -62,13 +62,13 @@ proc loopY(seive: var Sieve, x: int) =
     seive.step1(x, y)
     seive.step2(x, y)
     seive.step3(x, y)
-    y.inc(1)
+    y.inc()
 
 proc loopX(sieve: var Sieve) =
   var x = 1
   while x*x < sieve.limit:
     sieve.loopY(x)
-    x.inc(1)
+    x.inc()
 
 proc calc(sieve: var Sieve) =
   sieve.loopX()
@@ -127,4 +127,3 @@ when isMainModule:
   let result = find(UPPER_BOUND, PREFIX)
   notify("stop")
   echo result
-  

--- a/primes/primes.nim
+++ b/primes/primes.nim
@@ -1,0 +1,129 @@
+import strformat, strutils, sequtils
+import net
+import tables
+import posix
+import deques
+
+
+const UPPER_BOUND: int = 5_000_000;
+const PREFIX: int = 32_338;
+
+type
+  NodeRef = ref Node
+  Node = object
+    children: TableRef[char, NodeRef]
+    terminal: bool
+  Sieve = object
+    limit: int
+    primes: seq[bool]
+  Pair = object
+    node: NodeRef
+    str: string
+
+proc init(sieve: var Sieve) =
+  sieve.primes = newSeqWith(sieve.limit+1, false)
+
+
+proc toList(sieve: Sieve): seq[int] =
+  result = @[2, 3]
+  for p in 5..sieve.limit:
+    if sieve.primes[p]:
+      result.add(p)
+
+proc omitSquares(sieve: var Sieve) =
+  var r: int = 5;
+  while r * r < sieve.limit:
+    if sieve.primes[r]:
+      var i: int = r * r;
+      while i < sieve.limit:
+        sieve.primes[i] = false;
+        i += r * r
+    r.inc()
+
+proc step1(sieve: var Sieve, x, y: int): void =
+  let n: int = (4 * x * x) + (y * y);
+  if n <= sieve.limit and n mod 12 in [1, 5]:
+    sieve.primes[n] = not sieve.primes[n]
+
+
+proc step2(sieve: var Sieve, x, y: int): void =
+  let n: int = (3 * x * x) + (y * y)
+  if n <= sieve.limit and n mod 12 == 7:
+    sieve.primes[n] = not sieve.primes[n]
+
+proc step3(sieve: var Sieve, x, y: int): void =
+  let n: int = (3 * x * x) - (y * y)
+  if ( x > y and n < sieve.limit and n mod 12 == 11):
+    sieve.primes[n] = not sieve.primes[n]
+
+proc loopY(seive: var Sieve, x: int) =
+  var y: int = 1
+  while y*y < seive.limit:
+    seive.step1(x, y)
+    seive.step2(x, y)
+    seive.step3(x, y)
+    y += 1
+
+proc loopX(sieve: var Sieve) =
+  var x = 1
+  while x*x < sieve.limit:
+    sieve.loopY(x)
+    x += 1
+
+proc calc(sieve: var Sieve) =
+  sieve.loopX();
+  sieve.omitSquares()
+
+proc generateTrie(l: seq[int]): NodeRef =
+  result = NodeRef()
+  for el in l:
+    var head = result
+    for ch in $el:
+      if not head.children.hasKey(ch):
+        head.children[ch] = NodeRef()
+      head = head.children[ch]
+    head.terminal = true
+
+proc find(upperBound: int, prefix: int): seq[int] =
+  var primes = Sieve(limit: upperBound)
+  primes.init()
+  primes.calc()
+  var head = generateTrie(primes.toList())
+  for ch in $prefix:
+    head = head.children[ch]
+    if head == nil:
+      return @[]
+  var queue = @[Pair(node: head, str: $prefix)].toDeque()
+
+  while queue.len > 0:
+    var pair = queue.popLast()
+    if pair.node.terminal:
+      result.add(parseInt(pair.str))
+    for (ch, node) in pair.node.children.pairs():
+      queue.addFirst(Pair(node: node, str: pair.str & $ch))
+
+proc notify(msg: string) =
+  let sock = net.dial("127.0.0.1", Port(9001))
+  defer: sock.close()
+  sock.send(msg)
+  discard
+
+proc verify()  =
+  let left = @[2, 23, 29]
+  let right = find(100, 2)
+  try:
+    assert(left == right)
+  except:
+    echo "Expected: ", left
+    echo "Actual: ", right
+
+when isMainModule:
+  verify()
+
+  var compiler = "Nim/clang"
+  when defined(gcc):
+    compiler = "Nim/gcc"
+  notify(fmt"{compiler}\t{getpid()}")
+  let result = find(UPPER_BOUND, PREFIX)
+  notify("stop")
+  echo result

--- a/primes/primes.nim
+++ b/primes/primes.nim
@@ -5,13 +5,13 @@ import posix
 import deques
 
 
-const UPPER_BOUND: int = 5_000_000;
-const PREFIX: int = 32_338;
+const UPPER_BOUND: int = 5_000_000
+const PREFIX: int = 32_338
 
 type
   NodeRef = ref Node
   Node = object
-    children: TableRef[char, NodeRef]
+    children: Table[char, NodeRef]
     terminal: bool
   Sieve = object
     limit: int
@@ -21,7 +21,7 @@ type
     str: string
 
 proc init(sieve: var Sieve) =
-  sieve.primes = newSeqWith(sieve.limit+1, false)
+  sieve.primes = newSeqWith(sieve.limit + 1, false)
 
 
 proc toList(sieve: Sieve): seq[int] =
@@ -31,17 +31,17 @@ proc toList(sieve: Sieve): seq[int] =
       result.add(p)
 
 proc omitSquares(sieve: var Sieve) =
-  var r: int = 5;
+  var r: int = 5
   while r * r < sieve.limit:
     if sieve.primes[r]:
-      var i: int = r * r;
+      var i: int = r * r
       while i < sieve.limit:
-        sieve.primes[i] = false;
-        i += r * r
+        sieve.primes[i] = false
+        i.inc(r * r)
     r.inc()
 
 proc step1(sieve: var Sieve, x, y: int): void =
-  let n: int = (4 * x * x) + (y * y);
+  let n: int = (4 * x * x) + (y * y)
   if n <= sieve.limit and n mod 12 in [1, 5]:
     sieve.primes[n] = not sieve.primes[n]
 
@@ -53,7 +53,7 @@ proc step2(sieve: var Sieve, x, y: int): void =
 
 proc step3(sieve: var Sieve, x, y: int): void =
   let n: int = (3 * x * x) - (y * y)
-  if ( x > y and n < sieve.limit and n mod 12 == 11):
+  if x > y and n < sieve.limit and n mod 12 == 11:
     sieve.primes[n] = not sieve.primes[n]
 
 proc loopY(seive: var Sieve, x: int) =
@@ -62,16 +62,16 @@ proc loopY(seive: var Sieve, x: int) =
     seive.step1(x, y)
     seive.step2(x, y)
     seive.step3(x, y)
-    y += 1
+    y.inc(1)
 
 proc loopX(sieve: var Sieve) =
   var x = 1
   while x*x < sieve.limit:
     sieve.loopY(x)
-    x += 1
+    x.inc(1)
 
 proc calc(sieve: var Sieve) =
-  sieve.loopX();
+  sieve.loopX()
   sieve.omitSquares()
 
 proc generateTrie(l: seq[int]): NodeRef =
@@ -127,3 +127,4 @@ when isMainModule:
   let result = find(UPPER_BOUND, PREFIX)
   notify("stop")
   echo result
+  


### PR DESCRIPTION
Add nim primes to benchmark 

```bash
❯ nim c -d:release  --opt:speed  src/main.nim && time src/main
Hint: used config file '/Users/lantos/.choosenim/toolchains/nim-1.6.6/config/nim.cfg' [Conf]
Hint: used config file '/Users/lantos/.choosenim/toolchains/nim-1.6.6/config/config.nims' [Conf]
.....................................................................................................
CC: stdlib_dollars.nim
CC: stdlib_system.nim
CC: stdlib_tables.nim
CC: stdlib_deques.nim
CC: main.nim
Hint:  [Link]
Hint: gc: refc; opt: speed; options: -d:release
59684 lines; 1.141s; 75.52MiB peakmem; proj: /Users/lantos/Desktop/primes/src/main.nim; out: /Users/lantos/Desktop/primes/src/main [SuccessX]
@[323381, 323383, 3233863, 3233873, 3233887, 3233803, 3233809, 3233897, 3233851]
src/main  0.36s user 0.10s system 60% cpu 0.763 tot
```
compiles 