### PR TITLE
bf.swift: use unsafe buffer pointer to the tape

### DIFF
--- a/brainfuck/bf.swift
+++ b/brainfuck/bf.swift
@@ -16,8 +16,8 @@ struct Tape {
     var pos = 0
     var tape: ContiguousArray<Int32> = [0]
     var currentCell: Int32 {
-        get { tape[pos] }
-        set { tape[pos] = newValue }
+        get { tape.withUnsafeBufferPointer { $0[pos] } }
+        set { tape.withUnsafeMutableBufferPointer { $0[pos] = newValue } }
     }
 
     mutating func dec() {


### PR DESCRIPTION
Small optimization similar to the Rust version (7e2fc03).