### PR TITLE
Update V_FLAGS to use the COMMON_FLAGS too + the new -no-bounds-checking option

### DIFF
--- a/common/commands.mk
+++ b/common/commands.mk
@@ -5,7 +5,7 @@ LIBNOTIFY_FLAGS := -I../common/libnotify ../common/libnotify/target/libnotify.a
 NIM_FLAGS := -d:danger --verbosity:0 --opt:speed --hints:off --passC:"$(COMMON_FLAGS)" --passL:"-march=native -flto=auto"
 RUSTC_FLAGS := -C target-cpu=native -C llvm-args=--x86-branches-within-32B-boundaries
 VALAC_FLAGS := --disable-assert -X -O3 -X -march=native -X -flto -X -Wa,-mbranches-within-32B-boundaries --pkg gio-2.0 --pkg posix
-V_FLAGS := -prod
+V_FLAGS := -prod -no-bounds-checking -cflags "$(COMMON_FLAGS)"
 ZIG_FLAGS := -O ReleaseFast
 
 CLANG_BUILD =		clang $(CLANG_FLAGS) -std=c2x -o $@ $^ $(LIBNOTIFY_FLAGS)


### PR DESCRIPTION
Since today (from commit 9edb485), the main V compiler implementation, supports
a new option `-no-bounds-checking` . This PR updates V_FLAGS to use
it, and also to pass the COMMON_FLAGS to the C backend, just like
compilers for other languages do.