### PR TITLE
Add the -C strip=symbols flag to rustc

### DIFF
--- a/base64/base64.rs/Cargo.toml
+++ b/base64/base64.rs/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = true
 
 [dependencies]
 base64 = "0.13.0"

--- a/common/commands.mk
+++ b/common/commands.mk
@@ -27,7 +27,7 @@ MCS_BUILD =		mcs -debug- -optimize+ -out:$@ $^
 MLTON_BUILD =		mlton -output $@ $^
 NIM_CLANG_BUILD =	nim c -o:$@ --cc:clang $(NIM_FLAGS) $^
 NIM_GCC_BUILD =	nim c -o:$@ --cc:gcc $(NIM_FLAGS) $^
-RUSTC_BUILD =		rustc $(RUSTC_FLAGS) -C opt-level=3 -C lto -C codegen-units=1 -C panic=abort -o $@ $^
+RUSTC_BUILD =		rustc $(RUSTC_FLAGS) -C opt-level=3 -C lto -C codegen-units=1 -C panic=abort -C strip=symbols -o $@ $^
 RUST_CLIPPY =		clippy-driver -o $@.clippy $^
 SWIFTC_BUILD =		swiftc -parse-as-library -Ounchecked -cross-module-optimization -o $@ $^
 SCALAC_BUILD =		scalac -java-output-version 19 -d $@ $^

--- a/json/json.rs/Cargo.toml
+++ b/json/json.rs/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = true
 
 [dependencies]
 serde = { version = "1.0.137", features = ["derive"] }

--- a/matmul/rust-ndarray/Cargo.toml
+++ b/matmul/rust-ndarray/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = true
 
 [dependencies]
 ndarray = { version = "0.15.4", features = ["matrixmultiply-threading"]}


### PR DESCRIPTION
Add `-C strip=symbols` (the same as `strip = true` in the Cargo.toml) flag to remove debuginfo from binaries.