### PR TITLE
Modernize Rust code

### DIFF
--- a/base64/base64.rs/src/bin/base64.rs
+++ b/base64/base64.rs/src/bin/base64.rs
@@ -7,7 +7,7 @@ const STR_SIZE: usize = 131_072;
 const TRIES: usize = 8192;
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -16,12 +16,12 @@ fn main() {
     for [src, dst] in &[["hello", "aGVsbG8="], ["world", "d29ybGQ="]] {
         let encoded = base64::encode(&src);
         if encoded != *dst {
-            eprintln!("{:?} != {:?}", encoded, dst);
+            eprintln!("{encoded:?} != {dst:?}");
             process::exit(-1);
         }
         let decoded = String::from_utf8(base64::decode(&dst).unwrap()).unwrap();
         if decoded != *src {
-            eprintln!("{:?} != {:?}", decoded, src);
+            eprintln!("{decoded:?} != {src:?}");
             process::exit(-1);
         }
     }
@@ -30,7 +30,7 @@ fn main() {
     let output = base64::encode(&input);
     let str3 = base64::decode(&output).unwrap();
 
-    notify(&format!("Rust\t{}", process::id()));
+    notify(&format!("Rust\t{pid}", pid = process::id()));
 
     let time_start = Instant::now();
     let mut sum_encoded = 0;
@@ -49,18 +49,14 @@ fn main() {
     notify("stop");
 
     println!(
-        "encode {}... to {}...: {}, {}",
-        str::from_utf8(&input[..4]).unwrap(),
-        &output[..4],
-        sum_encoded,
-        t_encoded
+        "encode {input}... to {output}...: {sum_encoded}, {t_encoded}",
+        input = str::from_utf8(&input[..4]).unwrap(),
+        output = &output[..4]
     );
 
     println!(
-        "decode {}... to {}...: {}, {}",
-        &output[..4],
-        str::from_utf8(&str3[..4]).unwrap(),
-        sum_decoded,
-        t_decoded
+        "decode {output}... to {str3}...: {sum_decoded}, {t_decoded}",
+        output = &output[..4],
+        str3 = str::from_utf8(&str3[..4]).unwrap()
     );
 }

--- a/brainfuck/bf.rs
+++ b/brainfuck/bf.rs
@@ -138,7 +138,7 @@ impl Program {
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }

--- a/brainfuck/bf.rs
+++ b/brainfuck/bf.rs
@@ -144,18 +144,17 @@ fn notify(msg: &str) {
 }
 
 fn verify() {
-    const S: &[u8] = b"++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>\
-                       ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.";
+    const SOURCE: &[u8] = b"++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>\
+                            ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.";
+    let output = io::stdout();
 
     let left = {
-        let output = io::stdout();
         let mut p = Printer::new(&output, true);
-        Program::new(S).run(&mut p);
+        Program::new(SOURCE).run(&mut p);
         p.get_checksum()
     };
 
     let right = {
-        let output = io::stdout();
         let mut p = Printer::new(&output, true);
         for &c in b"Hello World!\n" {
             p.print(c as i32);
@@ -171,12 +170,12 @@ fn verify() {
 
 fn main() {
     verify();
-    let s = fs::read(env::args().nth(1).unwrap()).unwrap();
+    let source = fs::read(env::args().nth(1).unwrap()).unwrap();
     let output = io::stdout();
     let mut p = Printer::new(&output, env::var("QUIET").is_ok());
 
     notify(&format!("Rust\t{pid}", pid = process::id()));
-    Program::new(&s).run(&mut p);
+    Program::new(&source).run(&mut p);
     notify("stop");
 
     if p.quiet {

--- a/json/json.rs/src/json_jq.rs
+++ b/json/json.rs/src/json_jq.rs
@@ -22,7 +22,7 @@ impl Display for Coordinate {
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -38,7 +38,12 @@ fn calc(program: &mut JqProgram, content: &str) -> Coordinate {
 }
 
 fn main() {
-    let mut program = jq_rs::compile(".coordinates | length as $len | (map(.x) | add) / $len, (map(.y) | add) / $len, (map(.z) | add) / $len").unwrap();
+    let mut program = jq_rs::compile(concat!(
+        ".coordinates | length as $len | (map(.x) | add) / $len,",
+        " (map(.y) | add) / $len,",
+        " (map(.z) | add) / $len"
+    ))
+    .unwrap();
 
     let right = Coordinate {
         x: 2.0,
@@ -46,21 +51,21 @@ fn main() {
         z: 0.25,
     };
     for v in &[
-        "{\"coordinates\":[{\"x\":2.0,\"y\":0.5,\"z\":0.25}]}",
-        "{\"coordinates\":[{\"y\":0.5,\"x\":2.0,\"z\":0.25}]}",
+        r#"{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}"#,
+        r#"{"coordinates":[{"y":0.5,"x":2.0,"z":0.25}]}"#,
     ] {
         let left = calc(&mut program, v);
         if left != right {
-            eprintln!("{} != {}", left, right);
+            eprintln!("{left} != {right}");
             process::exit(-1);
         }
     }
 
     let content = fs::read_to_string("/tmp/1.json").unwrap();
 
-    notify(&format!("Rust (jq)\t{}", process::id()));
+    notify(&format!("Rust (jq)\t{pid}", pid = process::id()));
     let results = calc(&mut program, &content);
     notify("stop");
 
-    println!("{}", results);
+    println!("{results}");
 }

--- a/json/json.rs/src/json_jq.rs
+++ b/json/json.rs/src/json_jq.rs
@@ -39,7 +39,8 @@ fn calc(program: &mut JqProgram, content: &str) -> Coordinate {
 
 fn main() {
     let mut program = jq_rs::compile(concat!(
-        ".coordinates | length as $len | (map(.x) | add) / $len,",
+        ".coordinates | length as $len |",
+        " (map(.x) | add) / $len,",
         " (map(.y) | add) / $len,",
         " (map(.z) | add) / $len"
     ))

--- a/json/json.rs/src/json_pull.rs
+++ b/json/json.rs/src/json_pull.rs
@@ -76,7 +76,7 @@ where
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -99,21 +99,21 @@ fn main() {
         z: 0.25,
     };
     for v in &[
-        "{\"coordinates\":[{\"x\":2.0,\"y\":0.5,\"z\":0.25}]}",
-        "{\"coordinates\":[{\"y\":0.5,\"x\":2.0,\"z\":0.25}]}",
+        r#"{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}"#,
+        r#"{"coordinates":[{"y":0.5,"x":2.0,"z":0.25}]}"#,
     ] {
         let left = calc(v);
         if left != right {
-            eprintln!("{} != {}", left, right);
+            eprintln!("{left} != {right}");
             process::exit(-1);
         }
     }
 
     let content = fs::read_to_string("/tmp/1.json").unwrap();
 
-    notify(&format!("Rust (Serde Custom)\t{}", process::id()));
+    notify(&format!("Rust (Serde Custom)\t{pid}", pid = process::id()));
     let results = calc(&content);
     notify("stop");
 
-    println!("{}", results);
+    println!("{results}");
 }

--- a/json/json.rs/src/json_struct.rs
+++ b/json/json.rs/src/json_struct.rs
@@ -27,7 +27,7 @@ struct TestStruct {
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -60,21 +60,21 @@ fn main() {
         z: 0.25,
     };
     for v in &[
-        "{\"coordinates\":[{\"x\":2.0,\"y\":0.5,\"z\":0.25}]}",
-        "{\"coordinates\":[{\"y\":0.5,\"x\":2.0,\"z\":0.25}]}",
+        r#"{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}"#,
+        r#"{"coordinates":[{"y":0.5,"x":2.0,"z":0.25}]}"#,
     ] {
         let left = calc(v);
         if left != right {
-            eprintln!("{} != {}", left, right);
+            eprintln!("{left} != {right}");
             process::exit(-1);
         }
     }
 
     let s = fs::read_to_string("/tmp/1.json").unwrap();
 
-    notify(&format!("Rust (Serde Typed)\t{}", process::id()));
+    notify(&format!("Rust (Serde Typed)\t{pid}", pid = process::id()));
     let results = calc(&s);
     notify("stop");
 
-    println!("{}", results);
+    println!("{results}");
 }

--- a/json/json.rs/src/json_value.rs
+++ b/json/json.rs/src/json_value.rs
@@ -22,7 +22,7 @@ impl Display for Coordinate {
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -57,21 +57,21 @@ fn main() {
         z: 0.25,
     };
     for v in &[
-        "{\"coordinates\":[{\"x\":2.0,\"y\":0.5,\"z\":0.25}]}",
-        "{\"coordinates\":[{\"y\":0.5,\"x\":2.0,\"z\":0.25}]}",
+        r#"{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}"#,
+        r#"{"coordinates":[{"y":0.5,"x":2.0,"z":0.25}]}"#,
     ] {
         let left = calc(v);
         if left != right {
-            eprintln!("{} != {}", left, right);
+            eprintln!("{left} != {right}");
             process::exit(-1);
         }
     }
 
     let content = fs::read_to_string("/tmp/1.json").unwrap();
 
-    notify(&format!("Rust (Serde Untyped)\t{}", process::id()));
+    notify(&format!("Rust (Serde Untyped)\t{pid}", pid = process::id()));
     let results = calc(&content);
     notify("stop");
 
-    println!("{}", results);
+    println!("{results}");
 }

--- a/matmul/matmul.rs
+++ b/matmul/matmul.rs
@@ -43,7 +43,7 @@ fn mat_mul(a: &[Vec<f64>], b: &[Vec<f64>]) -> Vec<Vec<f64>> {
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -59,20 +59,19 @@ fn calc(n: usize) -> f64 {
 fn main() {
     let n = env::args()
         .nth(1)
-        .unwrap_or_else(|| "100".into())
-        .parse::<usize>()
-        .unwrap();
+        .and_then(|x| x.parse::<usize>().ok())
+        .unwrap_or(100);
 
     let left = calc(101);
     let right = -18.67;
     if (left - right).abs() > 0.1 {
-        eprintln!("{} != {}", left, right);
+        eprintln!("{left} != {right}");
         process::exit(-1);
     }
 
-    notify(&format!("Rust\t{}", process::id()));
+    notify(&format!("Rust\t{pid}", pid = process::id()));
     let results = calc(n);
     notify("stop");
 
-    println!("{}", results);
+    println!("{results}");
 }

--- a/matmul/rust-ndarray/src/main.rs
+++ b/matmul/rust-ndarray/src/main.rs
@@ -12,7 +12,7 @@ fn mat_gen(n: usize, seed: f64) -> Array2<f64> {
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -28,20 +28,19 @@ fn calc(n: usize) -> f64 {
 fn main() {
     let n = env::args()
         .nth(1)
-        .unwrap_or_else(|| "100".into())
-        .parse::<usize>()
-        .unwrap();
+        .and_then(|x| x.parse::<usize>().ok())
+        .unwrap_or(100);
 
     let left = calc(101);
     let right = -18.67;
     if (left - right).abs() > 0.1 {
-        eprintln!("{} != {}", left, right);
+        eprintln!("{left} != {right}");
         process::exit(-1);
     }
 
-    notify(&format!("Rust (ndarray)\t{}", process::id()));
+    notify(&format!("Rust (ndarray)\t{pid}", pid = process::id()));
     let results = calc(n);
     notify("stop");
 
-    println!("{}", results);
+    println!("{results}");
 }

--- a/primes/primes.rs
+++ b/primes/primes.rs
@@ -147,7 +147,7 @@ fn find(upper_bound: usize, prefix: i32) -> Vec<i32> {
 }
 
 fn notify(msg: &str) {
-    if let Ok(mut stream) = TcpStream::connect("localhost:9001") {
+    if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", 9001)) {
         stream.write_all(msg.as_bytes()).unwrap();
     }
 }
@@ -156,7 +156,7 @@ fn verify() {
     let left = vec![2, 23, 29];
     let right = find(100, 2);
     if left != right {
-        eprintln!("{:?} != {:?}", left, right);
+        eprintln!("{left:?} != {right:?}");
         process::exit(-1);
     }
 }
@@ -164,9 +164,9 @@ fn verify() {
 fn main() {
     verify();
 
-    notify(&format!("Rust\t{}", process::id()));
+    notify(&format!("Rust\t{pid}", pid = process::id()));
     let results = find(UPPER_BOUND, PREFIX);
     notify("stop");
 
-    println!("{:?}", results);
+    println!("{results:?}");
 }


### PR DESCRIPTION
* Use captured identifiers in format strings
* Use raw strings for JSON
* Break big string in lines with `concat!()`
* Use a tuple to represent a socket address
* Don't parse default value of env arg