### PR TITLE
Temporary fix for delayed server notification on quiet mode

### DIFF
--- a/brainfuck/bf.idr
+++ b/brainfuck/bf.idr
@@ -97,7 +97,7 @@ notify : String -> IO ()
 notify msg = do
   Right skt <- socket AF_INET Stream 0
   _ <- connect skt (Hostname "localhost") 9001
-  _ <- send skt msg
+  Right _ <- send skt msg
   close skt
 
 partial
@@ -110,13 +110,12 @@ main = do
   pid <- getPID
   notify $ "Idris\t" ++ show pid
   let ops = parse (unpack src)
-  _ <- runFresh ops
-  notify "stop"
-  -- case quiet of
-  --     Just _  => let cs = runQuiet ops
-  --                in do
-  --                  notify "stop"
-  --                  putStrLn $ "Output checksum: " ++ show (checkSum cs)
-  --     Nothing => do
-  --                  _ <- runFresh ops
-  --                  notify "stop"
+  case quiet of
+      Just _  => let cs = runQuiet ops
+                 in do
+                   notify "stop"
+                   putStrLn $ "Output checksum: " ++ show (checkSum cs)
+      Nothing => do
+                   _ <- runFresh ops
+                   notify "stop"
+  pure ()


### PR DESCRIPTION
For some reason, in quiet mode, the `notify $ "Idris"` line is delayed till the end, after the execution is complete, causing a reported 0s time. Adding `pure ()` at the end mysteriously forces it to be run at the expected time. This is possibly a compiler bug to be fixed later.

Tagging @edwinb in case he has insight into what's going on and if it's a bug that needs fixing.