### PR TITLE
Add staged Scala variant

### DIFF
--- a/brainfuck/scala-staged/build.sbt
+++ b/brainfuck/scala-staged/build.sbt
@@ -1,0 +1,14 @@
+val scala3Version = "3.2.2"
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    name := "bf",
+    version := "0.1.0",
+
+    scalaVersion := scala3Version,
+
+    libraryDependencies ++= Seq(
+      "org.scala-lang" %% "scala3-staging" % scala3Version
+    )
+  )

--- a/brainfuck/scala-staged/project/build.properties
+++ b/brainfuck/scala-staged/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.0

--- a/brainfuck/scala-staged/src/main/scala/Main.scala
+++ b/brainfuck/scala-staged/src/main/scala/Main.scala
@@ -1,0 +1,84 @@
+import scala.quoted.*
+import scala.collection.mutable.ArrayBuffer
+
+class Tape:
+  private var tape: Array[Int] = Array(0)
+  private var pos: Int = 0
+
+  def get = tape(pos)
+
+  def inc(x: Int) = tape(pos) += x
+
+  def move(x: Int) =
+    pos += x
+    if pos >= tape.length then
+      tape = Array.copyOf(tape, tape.length * 2)
+
+class Printer(val quiet: Boolean):
+  private var sum1, sum2: Int = 0
+
+  def write(n: Int) =
+    if quiet then
+      sum1 = (sum1 + n) % 255
+      sum2 = (sum2 + sum1) % 255
+    else print(n.toChar)
+
+  def checksum = (sum2 << 8) | sum1
+
+class Program(text: String, p: Printer):
+  def parse(using Quotes)(iter : Iterator[Char], t : Expr[Tape], p : Expr[Printer]) : Expr[Unit] =
+    val code = ArrayBuffer.empty[Expr[Unit]]
+    while (iter.hasNext) do
+      iter.next() match
+        case '+' => code += '{ $t.inc(1) }
+        case '-' => code += '{ $t.inc(-1) }
+        case '>' => code += '{ $t.move(1) }
+        case '<' => code += '{ $t.move(-1) }
+        case '.' => code += '{ $p.write($t.get) }
+        case '[' => code += '{ def body() = ${ parse(iter, t, p) }
+                               while $t.get > 0 do body()
+                             }
+        case ']' => return Expr.block(code.toList, '{})
+        case _ =>
+    Expr.block(code.toList, '{})
+
+  given staging.Compiler = staging.Compiler.make(getClass.getClassLoader)
+
+  val runOn : (Tape, Printer) => Unit =
+    staging.run('{ ((t : Tape, p : Printer) => ${ parse(text.iterator, 't, 'p) }) })
+
+  def run = runOn(Tape(), p)
+
+def notify(msg: String) =
+  scala.util.Using((java.net.Socket("localhost", 9001)).getOutputStream()) {
+      _.write(msg.getBytes())
+  }
+
+def verify =
+  val text = """++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>
+      ---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++."""
+  val pLeft = Printer(true)
+  Program(text, pLeft).run
+  val left = pLeft.checksum
+  val pRight = Printer(true)
+  for c <- "Hello World!\n" do
+    pRight.write(c)
+  val right = pRight.checksum
+  if left != right then
+      System.err.println(s"${left} != ${right}")
+      System.exit(1)
+
+@main def main(filename : String) : Unit =
+  verify
+  val text = scala.util.Using(scala.io.Source.fromFile(filename)) { _.mkString }.get
+  val p = Printer(sys.env.get("QUIET").isDefined)
+
+  notify(s"Scala (Staged)\t${ProcessHandle.current().pid()}")
+  val s = System.nanoTime
+  Program(text, p).run
+  val elapsed = (System.nanoTime - s) / 1e9
+  notify("stop")
+
+  System.err.println(s"time: $elapsed s")
+  if p.quiet then
+    System.out.println(s"Output checksum: ${p.checksum}")


### PR DESCRIPTION
This one starts from the main Scala variant, adops Scala 3's preferred [quiet  syntax](https://docs.scala-lang.org/scala3/reference/other-new-features/control-syntax.html), then uses Scala's [multi-stage programming](https://docs.scala-lang.org/scala3/reference/metaprogramming/staging.html) to apply the same technique in the `Racket (Syntax Objects)` variant. And the JVM is wicked fast!!

Unfortunately I couldn't figure out the more lightweight way to get it to work with just the compiler directly (i.e. `scalac -with-compiler -d out Main.scala` as they suggest in their docs), so I have to use [sbt](https://docs.scala-lang.org/getting-started/sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.html).

The commands I use to build and run are currently as follow:
```
$ cd scala-staged
$ sbt "run ../bench.b"
```