### PR TITLE
Rjson benchmarks (go)

### DIFF
--- a/json/Makefile
+++ b/json/Makefile
@@ -67,7 +67,9 @@ executables := \
 	target/json_zig \
 	target/json_yajl_gcc \
 	target/json_yajl_clang \
-	target/json_sonic
+	target/json_sonic \
+	target/json_rjson \
+	target/json_rjson_custom
 
 artifacts := $(executables) \
 	target/test.exe \
@@ -340,6 +342,12 @@ target/json_goccy: test_goccy.go | goccy
 
 target/json_sonic: test_sonic.go | $(gofmt)
 	go mod tidy
+	$(GO_BUILD)
+
+target/json_rjson: test_rjson.go
+	$(GO_BUILD)
+
+target/json_rjson_custom: test_rjson_custom.go
 	$(GO_BUILD)
 
 json-fsharp/target/Release/net7.0/json-fsharp: json-fsharp/json-fsharp.fsproj json-fsharp/Program.fs

--- a/json/go.mod
+++ b/json/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bytedance/sonic v1.10.1
 	github.com/goccy/go-json v0.10.2
 	github.com/json-iterator/go v1.1.12
+	github.com/willabides/rjson v0.2.0
 )
 
 require (

--- a/json/go.sum
+++ b/json/go.sum
@@ -29,6 +29,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -36,6 +37,10 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
+github.com/willabides/rjson v0.1.0 h1:RsKCjyFqCNjj4P6G8kJcddjLLqeyxYMs9ZiT1uU/ZUA=
+github.com/willabides/rjson v0.1.0/go.mod h1:9fWQED96t+VlaF7GPwf/qRHLdNbAjjBkaPxmmjyuW5E=
+github.com/willabides/rjson v0.2.0 h1:cgBIzis7l9ugUTtaLMcl12pJBu1m62oTBGf/XXBHhJI=
+github.com/willabides/rjson v0.2.0/go.mod h1:9fWQED96t+VlaF7GPwf/qRHLdNbAjjBkaPxmmjyuW5E=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670 h1:18EFjUmQOcUvxNYSkA6jO9VAiXCnxFY6NyDX0bHDmkU=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/json/test_rjson.go
+++ b/json/test_rjson.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+
+	"github.com/willabides/rjson"
+)
+
+type Coordinate struct {
+	X, Y, Z float64
+}
+
+type TestStruct struct {
+	Coordinates []Coordinate
+}
+
+func notify(msg string) {
+	conn, err := net.Dial("tcp", "localhost:9001")
+	if err == nil {
+		fmt.Fprintf(conn, msg)
+		conn.Close()
+	}
+}
+
+func calc(bytes []byte) Coordinate {
+	jobj := TestStruct{}
+
+	var buffer rjson.Buffer
+	var currentCoord *Coordinate
+
+	coordHandler := rjson.ObjectValueHandlerFunc(func(fieldname, data []byte) (int, error) {
+		switch string(fieldname) {
+		case "x":
+			return rjson.DecodeFloat64(data, &currentCoord.X)
+		case "y":
+			return rjson.DecodeFloat64(data, &currentCoord.Y)
+		case "z":
+			return rjson.DecodeFloat64(data, &currentCoord.Z)
+		}
+		return rjson.SkipValueFast(data, &buffer)
+	})
+
+	coordsHandler := rjson.ArrayValueHandlerFunc(func(data []byte) (int, error) {
+		jobj.Coordinates = append(jobj.Coordinates, Coordinate{})
+		currentCoord = &jobj.Coordinates[len(jobj.Coordinates)-1]
+		return rjson.HandleObjectValues(data, coordHandler, &buffer)
+	})
+
+	rjson.HandleObjectValues(bytes, rjson.ObjectValueHandlerFunc(func(fieldname, data []byte) (int, error) {
+		if string(fieldname) != "coordinates" {
+			return rjson.SkipValueFast(data, &buffer)
+		}
+		return rjson.HandleArrayValues(data, coordsHandler, &buffer)
+	}), &buffer)
+
+	x, y, z := 0.0, 0.0, 0.0
+
+	for _, coord := range jobj.Coordinates {
+		x += coord.X
+		y += coord.Y
+		z += coord.Z
+	}
+
+	len := float64(len(jobj.Coordinates))
+	return Coordinate{x / len, y / len, z / len}
+}
+
+func main() {
+	right := Coordinate{2.0, 0.5, 0.25}
+	for _, v := range []string{
+		`{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}`,
+		`{"coordinates":[{"y":0.5,"x":2.0,"z":0.25}]}`} {
+		left := calc([]byte(v))
+		if left != right {
+			log.Fatalf("%+v != %+v\n", left, right)
+		}
+	}
+
+	bytes, err := ioutil.ReadFile("/tmp/1.json")
+	if err != nil {
+		panic(fmt.Sprintf("%v", err))
+	}
+
+	notify(fmt.Sprintf("Go (rjson)\t%d", os.Getpid()))
+	results := calc(bytes)
+	notify("stop")
+
+	fmt.Printf("%+v\n", results)
+}

--- a/json/test_rjson_custom.go
+++ b/json/test_rjson_custom.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+
+	"github.com/willabides/rjson"
+)
+
+type Coordinate struct {
+	X, Y, Z float64
+}
+
+func notify(msg string) {
+	conn, err := net.Dial("tcp", "localhost:9001")
+	if err == nil {
+		fmt.Fprintf(conn, msg)
+		conn.Close()
+	}
+}
+
+type handler struct {
+	buffer rjson.Buffer
+	coord  Coordinate
+	count  float64 // used to calculate the running average
+}
+
+func (h *handler) HandleArrayValue(data []byte) (p int, err error) {
+	h.count++
+	return rjson.HandleObjectValues(data, h, &h.buffer)
+}
+
+// HandleObjectValue handles both the top level object where we only care about the "coordinates" field
+// and the object inside the array where we keep a running average of x, y, and z values.
+func (h *handler) HandleObjectValue(fieldname, data []byte) (int, error) {
+	var ptr *float64 // points to X, Y or Z depending on the fieldname
+	switch string(fieldname) {
+	case "x":
+		ptr = &h.coord.X
+	case "y":
+		ptr = &h.coord.Y
+	case "z":
+		ptr = &h.coord.Z
+	case "coordinates":
+		return rjson.HandleArrayValues(data, h, &h.buffer)
+	default:
+		return rjson.SkipValueFast(data, &h.buffer)
+	}
+	val, p, err := rjson.ReadFloat64(data)
+	if err != nil {
+		return p, err
+	}
+	*ptr += val
+	return p, nil
+}
+
+func calc(bytes []byte) Coordinate {
+	h := &handler{}
+	rjson.HandleObjectValues(bytes, h, &h.buffer)
+	return Coordinate{
+		X: h.coord.X / h.count,
+		Y: h.coord.Y / h.count,
+		Z: h.coord.Z / h.count,
+	}
+}
+
+func main() {
+	right := Coordinate{2.0, 0.5, 0.25}
+	for _, v := range []string{
+		`{"coordinates":[{"x":2.0,"y":0.5,"z":0.25}]}`,
+		`{"coordinates":[{"y":0.5,"x":2.0,"z":0.25}]}`} {
+		left := calc([]byte(v))
+		if left != right {
+			log.Fatalf("%+v != %+v\n", left, right)
+		}
+	}
+
+	bytes, err := ioutil.ReadFile("/tmp/1.json")
+	if err != nil {
+		panic(fmt.Sprintf("%v", err))
+	}
+
+	notify(fmt.Sprintf("Go (rjson custom)\t%d", os.Getpid()))
+	results := calc(bytes)
+	notify("stop")
+
+	fmt.Printf("%+v\n", results)
+}


### PR DESCRIPTION
This adds two Go benchmarks using https://github.com/willabides/rjson. 

"Go (rjson)" uses the traditional approach of building a `TestStruct` with a Coordinate for each value in the json.

"Go (rjson custom)" takes a page from "Rust (Serde Custom)" and uses a single Coordinate value.

On my machine both of these are a little faster than "Go(Sonic)".