### PR TITLE
Remove obsolete increments of len variable in Odin test

### DIFF
--- a/json/test.odin
+++ b/json/test.odin
@@ -29,18 +29,13 @@ calc :: proc(s: string) -> Coordinate {
 	x := 0.0
 	y := 0.0
 	z := 0.0
-	len := 0.0
 	for coord in j.coordinates {
 		x += coord.x
 		y += coord.y
 		z += coord.z
-		len += 1
 	}
-	return Coordinate{
-		x = x / len,
-		y = y / len,
-		z = z / len,
-	}
+	len := f64(len(j.coordinates))
+	return Coordinate{x = x / len, y = y / len, z = z / len}
 }
 
 main :: proc() {


### PR DESCRIPTION
Adding the additional len variable and mutating it in the loop introduces a slowdown of about 5-10%.

The formatting changes are made by ols/odinfmt.