### PR TITLE
Resolve TODO in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -298,8 +298,7 @@ RUN curl -Lo odin-linux-amd64-dev-$ODIN.zip \
 ENV PATH="/root/bin/odin-linux-amd64-nightly+$ODIN-04/:${PATH}"
 
 # https://github.com/vlang/vsl and dependencies
-# TODO - Install using specific VSL version as ARG
-RUN v install vsl
+RUN v install vsl@v0.1.50
 
 # https://www.haskell.org/ghc/
 ARG GHC_VER=9.8.2


### PR DESCRIPTION
The PR resolves a ToDo in the Dockefile regarding pinning a version to make things less prone to breaks in development blobs.

The possibility to specify a version via `@<version>` was potentially added after the TODO was written.